### PR TITLE
Sql builder improvements

### DIFF
--- a/src/__mocks__/datasource.ts
+++ b/src/__mocks__/datasource.ts
@@ -1,5 +1,5 @@
 import { PluginType } from '@grafana/data';
-import { QuestDBQuery, QueryType } from '../types';
+import {QuestDBQuery, QueryType} from '../types';
 import { Datasource } from '../data/QuestDbDatasource';
 
 export const mockDatasource = new Datasource({
@@ -36,6 +36,7 @@ export const mockDatasource = new Datasource({
     },
   },
 });
+
 export const mockQuery: QuestDBQuery = {
   rawSql: 'select * from foo',
   refId: '',

--- a/src/components/QueryHeader.tsx
+++ b/src/components/QueryHeader.tsx
@@ -5,14 +5,16 @@ import { FormatSelect } from '../components/FormatSelect';
 import { Button } from '@grafana/ui';
 import { getFormat } from 'components/editor';
 import { EditorHeader, FlexItem } from '@grafana/experimental';
+import {Datasource} from "../data/QuestDbDatasource";
 
 interface QueryHeaderProps {
   query: QuestDBQuery;
   onChange: (query: QuestDBQuery) => void;
   onRunQuery: () => void;
+  datasource: Datasource;
 }
 
-export const QueryHeader = ({ query, onChange, onRunQuery}: QueryHeaderProps) => {
+export const QueryHeader = ({ query, onChange, onRunQuery, datasource}: QueryHeaderProps) => {
   React.useEffect(() => {
     if (typeof query.selectedFormat === 'undefined' && query.queryType === QueryType.SQL) {
       const selectedFormat = Format.AUTO;
@@ -49,7 +51,7 @@ export const QueryHeader = ({ query, onChange, onRunQuery}: QueryHeaderProps) =>
 
   return (
     <EditorHeader>
-      <QueryTypeSwitcher query={query} onChange={onChange} />
+      <QueryTypeSwitcher query={query} onChange={onChange} datasource={datasource} />
       <FlexItem grow={1} />
       <Button variant="primary" icon="play" size="sm" onClick={runQuery}>
         Run query

--- a/src/components/queryBuilder/Metrics.tsx
+++ b/src/components/queryBuilder/Metrics.tsx
@@ -72,6 +72,7 @@ const MetricEditor = (props: {
         onOpenMenu={() => setIsOpen(true)}
         onCloseMenu={() => setIsOpen(false)}
         onChange={onMetricFieldChange}
+        allowCustomValue={true}
         value={metric.field}
       />
       <InlineFormLabel width={2} className="query-keyword">

--- a/src/views/QuestDBQueryEditor.tsx
+++ b/src/views/QuestDBQueryEditor.tsx
@@ -87,7 +87,7 @@ export const QuestDBQueryEditor = (props: QuestDBQueryEditorProps) => {
 
   return (
     <>
-      <QueryHeader query={query} onChange={onChange} onRunQuery={onRunQuery} />
+      <QueryHeader query={query} onChange={onChange} onRunQuery={onRunQuery} datasource={props.datasource}/>
       <QuestDBEditorByType {...props} />
     </>
   );


### PR DESCRIPTION
Changes:
- removed quoting of columns to make it possible to use select expressions in builder
- improved editor sql to builder conversion by:
  - handling more types of expressions 
  - ignoring only select expressions that can't be used, instead of returning empty fields list
  - flattening complex condition hierarchy (instead of logging to console and stopping action)
