### PR TITLE
Fix triggering autocomplete on newlines

### DIFF
--- a/src/components/questdb-sql/createSchemaCompletionProvider.ts
+++ b/src/components/questdb-sql/createSchemaCompletionProvider.ts
@@ -84,12 +84,23 @@ export const createSchemaCompletionProvider = (
           const openQuote = textUntilPosition.substr(-1) === '"'
           const nextCharQuote = nextChar === '"'
 
+          // get text value in the current line
+          const textInLine = model.getValueInRange({
+            startLineNumber: position.lineNumber,
+            startColumn: 1,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          })
+          // check if `textInLine` contains whitespaces only
+          const isWhitespaceOnly = /^\s*$/.test(textInLine)
+
           if (
-            /(FROM|INTO|(ALTER|BACKUP|DROP|REINDEX|RENAME|TRUNCATE|VACUUM) TABLE|JOIN|UPDATE)\s$/gim.test(
-              textUntilPosition,
-            ) ||
-            (/'$/gim.test(textUntilPosition) &&
-              !textUntilPosition.endsWith("= '"))
+            (/(FROM|INTO|(ALTER|BACKUP|DROP|REINDEX|RENAME|TRUNCATE|VACUUM) TABLE|JOIN|UPDATE)\s$/gim.test(
+                textUntilPosition,
+              ) ||
+              (/'$/gim.test(textUntilPosition) &&
+                !textUntilPosition.endsWith("= '"))) &&
+            !isWhitespaceOnly
           ) {
             return {
               suggestions: getTableCompletions({
@@ -101,16 +112,6 @@ export const createSchemaCompletionProvider = (
               }),
             }
           }
-
-          // get text value in the current line
-          const textInLine = model.getValueInRange({
-            startLineNumber: position.lineNumber,
-            startColumn: 1,
-            endLineNumber: position.lineNumber,
-            endColumn: position.column,
-          })
-          // check if `textInLine` contains whitespaces only
-          const isWhitespaceOnly = /^\s*$/.test(textInLine)
 
           if (
             /(?:(SELECT|UPDATE).*?(?:(?:,(?:COLUMN )?)|(?:ALTER COLUMN ))?(?:WHERE )?(?: BY )?(?: ON )?(?: SET )?$|ALTER COLUMN )/gim.test(


### PR DESCRIPTION
Cherry pick from https://github.com/questdb/ui/pull/267.

This fixes the case in which table name autocomplete is triggered upon hitting Enter and starting the line indented. 