### PR TITLE
Remove `TLS Method` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ example, statements like `UPDATE users SET name='blahblah'`
 and `DROP TABLE importantTable;` would be executed.
 
 To configure a readonly user, follow these steps:
-* Open Source version
+
+- Open Source version
   1. Set the following properties in server.conf file:
      - pg.readonly.user.enabled=true
      - pg.readonly.user=myuser
      - pg.readonly.password=secret
   2. Restart QuestDB instance.
-* Enterprise version
+- Enterprise version
   1. Create user:
      - CREATE USER grafana_readonly;
-  2. Grant read permission on selected tables/table columns   ; 
+  2. Grant read permission on selected tables/table columns ;
      - GRANT SELECT ON table1, ... TO grafana_readonly;
 
 ### Manual configuration
@@ -58,7 +59,6 @@ datasources:
       port: 8812
       username: admin
       tlsMode: disable
-      # tlsConfigurationMethod: file-path | file-content
       # tlsCACertFile: <string>
       # timeout: <seconds>
       # queryTimeout: <seconds>
@@ -88,11 +88,13 @@ interprets timestamp rows without explicit time zone as UTC. Any column except
 
 To create multi-line time series, the query must return at least 3 fields in
 the following order:
-- field 1:  `timestamp` field with an alias of `time`
-- field 2:  value to group by
+
+- field 1: `timestamp` field with an alias of `time`
+- field 2: value to group by
 - field 3+: the metric values
 
 For example:
+
 ```sql
 SELECT pickup_datetime AS time, cab_type, avg(fare_amount) AS avg_fare_amount
 FROM trips
@@ -109,24 +111,25 @@ Table visualizations will always be available for any valid QuestDB query.
 To simplify syntax and to allow for dynamic parts, like date range filters, the query can contain macros.
 
 Here is an example of a query with a macro that will use Grafana's time filter:
+
 ```sql
 SELECT desginated_timestamp, data_stuff
 FROM test_data
 WHERE $__timeFilter(desginated_timestamp)
 ```
 
-| Macro                                        | Description                                                                                                                                                                         | Output example                                                                                     |
-|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| *$__timeFilter(columnName)*                  | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in seconds                                                         | `timestamp >= cast(1706263425598000 as timestamp) AND timestamp <= cast(1706285057560000 as timestamp)` |
-| *$__fromTime*                                | Replaced by the starting time of the range of the panel cast to timestamp                                                                                                           | `cast(1706263425598000 as timestamp)`                                                              |
-| *$__toTime*                                  | Replaced by the ending time of the range of the panel cast to timestamp                                                                                                             | `cast(1706285057560000 as timestamp)`                                                              |
-| *$__sampleByInterval*                        | Replaced by the interval followed by unit: d, h, s or T (millisecond). Example: 1d, 5h, 20s, 1T.                                                                                    | `20s` (20 seconds) , `1T` (1 millisecond)                                                          |
-| *$__conditionalAll(condition, $templateVar)* | Replaced by the first parameter when the template variable in the second parameter does not select every value. Replaced by the 1=1 when the template variable selects every value. | `condition` or `1=1`                                                                               |
+| Macro                                          | Description                                                                                                                                                                         | Output example                                                                                          |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| _$\_\_timeFilter(columnName)_                  | Replaced by a conditional that filters the data (using the provided column) based on the time range of the panel in seconds                                                         | `timestamp >= cast(1706263425598000 as timestamp) AND timestamp <= cast(1706285057560000 as timestamp)` |
+| _$\_\_fromTime_                                | Replaced by the starting time of the range of the panel cast to timestamp                                                                                                           | `cast(1706263425598000 as timestamp)`                                                                   |
+| _$\_\_toTime_                                  | Replaced by the ending time of the range of the panel cast to timestamp                                                                                                             | `cast(1706285057560000 as timestamp)`                                                                   |
+| _$\_\_sampleByInterval_                        | Replaced by the interval followed by unit: d, h, s or T (millisecond). Example: 1d, 5h, 20s, 1T.                                                                                    | `20s` (20 seconds) , `1T` (1 millisecond)                                                               |
+| _$\_\_conditionalAll(condition, $templateVar)_ | Replaced by the first parameter when the template variable in the second parameter does not select every value. Replaced by the 1=1 when the template variable selects every value. | `condition` or `1=1`                                                                                    |
 
 The plugin also supports notation using braces {}. Use this notation when queries are needed inside parameters.
 
-Additionally, Grafana has the built-in [`$__interval` macro][query-transform-data-query-options], which calculates an interval in seconds or milliseconds. 
-It shouldn't be used with SAMPLE BY because of time unit incompatibility, 1ms vs 1T (expected by QuestDB). Use `$__sampleByInterval` instead.  
+Additionally, Grafana has the built-in [`$__interval` macro][query-transform-data-query-options], which calculates an interval in seconds or milliseconds.
+It shouldn't be used with SAMPLE BY because of time unit incompatibility, 1ms vs 1T (expected by QuestDB). Use `$__sampleByInterval` instead.
 
 ### Templates and variables
 
@@ -144,12 +147,12 @@ Ad hoc filters allow you to add key/value filters that are automatically added
 to all metric queries that use the specified data source, without being
 explicitly used in queries.
 
-By default, Ad Hoc filters will be populated with all Tables and Columns.  If
+By default, Ad Hoc filters will be populated with all Tables and Columns. If
 you have a default database defined in the Datasource settings, all Tables from
 that database will be used to populate the filters. As this could be
 slow/expensive, you can introduce a second variable to allow limiting the
 Ad Hoc filters. It should be a `constant` type named `questdb_adhoc_query`
-and can contain: a comma delimited list of tables  to show only columns for one or more tables.
+and can contain: a comma delimited list of tables to show only columns for one or more tables.
 
 For more information on Ad Hoc filters, check the [Grafana
 docs](https://grafana.com/docs/grafana/latest/variables/variable-types/add-ad-hoc-filters/)
@@ -162,7 +165,7 @@ You may choose to hide this variable from view as it serves no further purpose.
 
 ## Learn more
 
-* Add [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations/).
-* Configure and use [Templates and variables](https://grafana.com/docs/grafana/latest/variables/).
-* Add [Transformations](https://grafana.com/docs/grafana/latest/panels/transformations/).
-* Set up alerting; refer to [Alerts overview](https://grafana.com/docs/grafana/latest/alerting/).
+- Add [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations/).
+- Configure and use [Templates and variables](https://grafana.com/docs/grafana/latest/variables/).
+- Add [Transformations](https://grafana.com/docs/grafana/latest/panels/transformations/).
+- Set up alerting; refer to [Alerts overview](https://grafana.com/docs/grafana/latest/alerting/).

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -124,69 +124,50 @@ func GenerateConnectionString(settings Settings, version string) (string, error)
 	connStr += fmt.Sprintf(" sslmode='%s'", escape(mode))
 
 	if mode != "disable" {
-		if settings.ConfigurationMethod == "file-content" {
-			connStr += " sslinline=true"
+		connStr += " sslinline=true"
 
-			// Attach root certificate if provided
-			if settings.TlsCACert != "" {
-				log.DefaultLogger.Debug("Setting server root certificate", "tlsRootCert", settings.TlsCACert)
-				connStr += fmt.Sprintf(" sslrootcert='%s'", escape(settings.TlsCACert))
-			}
+		// Attach root certificate if provided
+		if settings.TlsCACert != "" {
+			log.DefaultLogger.Debug("Setting server root certificate", "tlsRootCert", settings.TlsCACert)
+			connStr += fmt.Sprintf(" sslrootcert='%s'", escape(settings.TlsCACert))
+		}
 
-			// Attach client certificate and key if both are provided
-			if settings.TlsClientCert != "" && settings.TlsClientKey != "" {
-				log.DefaultLogger.Debug("Setting TLS/SSL client auth", "tlsCert", settings.TlsClientCert, "tlsKey", settings.TlsClientKey)
-				connStr += fmt.Sprintf(" sslcert='%s' sslkey='%s'", escape(settings.TlsClientCert), escape(settings.TlsClientKey))
-			} else if settings.TlsClientCert != "" || settings.TlsClientKey != "" {
-				return "", fmt.Errorf("TLS/SSL client certificate and key must both be specified")
-			} else {
-				//HACK: sslinline fails if client key or cert are empty, so we use sample ones [they're ignored by qdb anyway]
-				tlsClientCert := `
------BEGIN CERTIFICATE-----
-MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
-A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
-MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
-YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
-ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
-CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
-ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
-8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
-AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
-8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
-2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
-Hn+GmxZA
------END CERTIFICATE-----
-`
-				tlsClientKey := `
------BEGIN RSA PRIVATE KEY-----
-MIIBOwIBAAJBAJv8ZpB5hEK7qxP9K3v43hUS5fGT4waKe7ix4Z4mu5UBv+cw7WSF
-At0Vaag0sAbsPzU8Hhsrj/qPABvfB8asUwcCAwEAAQJAG0r3ezH35WFG1tGGaUOr
-QA61cyaII53ZdgCR1IU8bx7AUevmkFtBf+aqMWusWVOWJvGu2r5VpHVAIl8nF6DS
-kQIhAMjEJ3zVYa2/Mo4ey+iU9J9Vd+WoyXDQD4EEtwmyG1PpAiEAxuZlvhDIbbce
-7o5BvOhnCZ2N7kYb1ZC57g3F+cbJyW8CIQCbsDGHBto2qJyFxbAO7uQ8Y0UVHa0J
-BO/g900SAcJbcQIgRtEljIShOB8pDjrsQPxmI1BLhnjD1EhRSubwhDw5AFUCIQCN
-A24pDtdOHydwtSB5+zFqFLfmVZplQM/g5kb4so70Yw==
------END RSA PRIVATE KEY-----
-`
-				connStr += fmt.Sprintf(" sslcert='%s' sslkey='%s'", escape(tlsClientCert), escape(tlsClientKey))
-			}
-
-		} else if settings.ConfigurationMethod == "file-path" {
-			// Attach root certificate if provided
-			if settings.TlsCACertFile != "" {
-				log.DefaultLogger.Debug("Setting server root certificate", "tlsRootCertFile", settings.TlsCACertFile)
-				connStr += fmt.Sprintf(" sslrootcert='%s'", escape(settings.TlsCACertFile))
-			}
-
-			// Attach client certificate and key if both are provided
-			if settings.TlsClientCertFile != "" && settings.TlsClientKeyFile != "" {
-				log.DefaultLogger.Debug("Setting TLS/SSL client auth", "tlsCertFile", settings.TlsClientCertFile, "tlsKeyFile", settings.TlsClientKeyFile)
-				connStr += fmt.Sprintf(" sslcert='%s' sslkey='%s'", escape(settings.TlsClientCertFile), escape(settings.TlsClientKeyFile))
-			} else if settings.TlsClientCertFile != "" || settings.TlsClientKeyFile != "" {
-				return "", fmt.Errorf("TLS/SSL client certificate and key files must both be specified")
-			}
-		} else if settings.ConfigurationMethod != "" {
-			return "", errors.New(fmt.Sprintf("invalid ssl configuration method: %s", settings.ConfigurationMethod))
+		// Attach client certificate and key if both are provided
+		if settings.TlsClientCert != "" && settings.TlsClientKey != "" {
+			log.DefaultLogger.Debug("Setting TLS/SSL client auth", "tlsCert", settings.TlsClientCert, "tlsKey", settings.TlsClientKey)
+			connStr += fmt.Sprintf(" sslcert='%s' sslkey='%s'", escape(settings.TlsClientCert), escape(settings.TlsClientKey))
+		} else if settings.TlsClientCert != "" || settings.TlsClientKey != "" {
+			return "", fmt.Errorf("TLS/SSL client certificate and key must both be specified")
+		} else {
+			//HACK: sslinline fails if client key or cert are empty, so we use sample ones [they're ignored by qdb anyway]
+			tlsClientCert := `
+			-----BEGIN CERTIFICATE-----
+			MIICEjCCAXsCAg36MA0GCSqGSIb3DQEBBQUAMIGbMQswCQYDVQQGEwJKUDEOMAwG
+			A1UECBMFVG9reW8xEDAOBgNVBAcTB0NodW8ta3UxETAPBgNVBAoTCEZyYW5rNERE
+			MRgwFgYDVQQLEw9XZWJDZXJ0IFN1cHBvcnQxGDAWBgNVBAMTD0ZyYW5rNEREIFdl
+			YiBDQTEjMCEGCSqGSIb3DQEJARYUc3VwcG9ydEBmcmFuazRkZC5jb20wHhcNMTIw
+			ODIyMDUyNjU0WhcNMTcwODIxMDUyNjU0WjBKMQswCQYDVQQGEwJKUDEOMAwGA1UE
+			CAwFVG9reW8xETAPBgNVBAoMCEZyYW5rNEREMRgwFgYDVQQDDA93d3cuZXhhbXBs
+			ZS5jb20wXDANBgkqhkiG9w0BAQEFAANLADBIAkEAm/xmkHmEQrurE/0re/jeFRLl
+			8ZPjBop7uLHhnia7lQG/5zDtZIUC3RVpqDSwBuw/NTweGyuP+o8AG98HxqxTBwID
+			AQABMA0GCSqGSIb3DQEBBQUAA4GBABS2TLuBeTPmcaTaUW/LCB2NYOy8GMdzR1mx
+			8iBIu2H6/E2tiY3RIevV2OW61qY2/XRQg7YPxx3ffeUugX9F4J/iPnnu1zAxxyBy
+			2VguKv4SWjRFoRkIfIlHX0qVviMhSlNy2ioFLy7JcPZb+v3ftDGywUqcBiVDoea0
+			Hn+GmxZA
+			-----END CERTIFICATE-----
+			`
+			tlsClientKey := `
+			-----BEGIN RSA PRIVATE KEY-----
+			MIIBOwIBAAJBAJv8ZpB5hEK7qxP9K3v43hUS5fGT4waKe7ix4Z4mu5UBv+cw7WSF
+			At0Vaag0sAbsPzU8Hhsrj/qPABvfB8asUwcCAwEAAQJAG0r3ezH35WFG1tGGaUOr
+			QA61cyaII53ZdgCR1IU8bx7AUevmkFtBf+aqMWusWVOWJvGu2r5VpHVAIl8nF6DS
+			kQIhAMjEJ3zVYa2/Mo4ey+iU9J9Vd+WoyXDQD4EEtwmyG1PpAiEAxuZlvhDIbbce
+			7o5BvOhnCZ2N7kYb1ZC57g3F+cbJyW8CIQCbsDGHBto2qJyFxbAO7uQ8Y0UVHa0J
+			BO/g900SAcJbcQIgRtEljIShOB8pDjrsQPxmI1BLhnjD1EhRSubwhDw5AFUCIQCN
+			A24pDtdOHydwtSB5+zFqFLfmVZplQM/g5kb4so70Yw==
+			-----END RSA PRIVATE KEY-----
+			`
+			connStr += fmt.Sprintf(" sslcert='%s' sslkey='%s'", escape(tlsClientCert), escape(tlsClientKey))
 		}
 	}
 

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/lib/pq"
 	"math"
 	"os"
 	"path"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/api/types/mount"
+	"github.com/lib/pq"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -150,7 +151,6 @@ func setupConnection(t *testing.T) *sql.DB {
 	username := getEnv("QUESTDB_USERNAME", "admin")
 	password := getEnv("QUESTDB_PASSWORD", "quest")
 	tlsEnabled := getEnv("QUESTDB_TLS_ENABLED", "false")
-	tlsConfigurationMethod := getEnv("QUESTDB_METHOD", "file-content")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -170,13 +170,12 @@ func setupConnection(t *testing.T) *sql.DB {
 	}
 
 	cnnstr, err := plugin.GenerateConnectionString(plugin.Settings{
-		Server:              host,
-		Port:                port,
-		Username:            username,
-		Password:            password,
-		TlsMode:             tlsMode,
-		ConfigurationMethod: tlsConfigurationMethod,
-		TlsCACert:           string(tlsCaCert),
+		Server:    host,
+		Port:      port,
+		Username:  username,
+		Password:  password,
+		TlsMode:   tlsMode,
+		TlsCACert: string(tlsCaCert),
 	}, "version")
 	if err != nil {
 		panic(err)

--- a/pkg/plugin/driver_test.go
+++ b/pkg/plugin/driver_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/lib/pq"
 	"math"
 	"os"
 	"path"
@@ -12,9 +14,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/docker/docker/api/types/mount"
-	"github.com/lib/pq"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -151,6 +150,7 @@ func setupConnection(t *testing.T) *sql.DB {
 	username := getEnv("QUESTDB_USERNAME", "admin")
 	password := getEnv("QUESTDB_PASSWORD", "quest")
 	tlsEnabled := getEnv("QUESTDB_TLS_ENABLED", "false")
+	tlsConfigurationMethod := getEnv("QUESTDB_METHOD", "file-content")
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -170,12 +170,13 @@ func setupConnection(t *testing.T) *sql.DB {
 	}
 
 	cnnstr, err := plugin.GenerateConnectionString(plugin.Settings{
-		Server:    host,
-		Port:      port,
-		Username:  username,
-		Password:  password,
-		TlsMode:   tlsMode,
-		TlsCACert: string(tlsCaCert),
+		Server:              host,
+		Port:                port,
+		Username:            username,
+		Password:            password,
+		TlsMode:             tlsMode,
+		ConfigurationMethod: tlsConfigurationMethod,
+		TlsCACert:           string(tlsCaCert),
 	}, "version")
 	if err != nil {
 		panic(err)

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -29,8 +29,7 @@ type Settings struct {
 	MaxIdleConnections    int64 `json:"maxIdleConnections,omitempty"`
 	MaxConnectionLifetime int64 `json:"maxConnectionLifetime,omitempty"`
 
-	TlsMode             string `json:"tlsMode"`
-	ConfigurationMethod string `json:"tlsConfigurationMethod"`
+	TlsMode string `json:"tlsMode"`
 
 	TlsCACertFile     string `json:"tlsCaCertFile"`
 	TlsClientCertFile string `json:"tlsClientCertFile"`
@@ -123,9 +122,6 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		settings.TlsClientKey = tlsClientKey
 	}
 
-	if jsonData["tlsConfigurationMethod"] != nil {
-		settings.ConfigurationMethod = jsonData["tlsConfigurationMethod"].(string)
-	}
 	if jsonData["tlsMode"] != nil {
 		settings.TlsMode = jsonData["tlsMode"].(string)
 	}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -29,7 +29,8 @@ type Settings struct {
 	MaxIdleConnections    int64 `json:"maxIdleConnections,omitempty"`
 	MaxConnectionLifetime int64 `json:"maxConnectionLifetime,omitempty"`
 
-	TlsMode string `json:"tlsMode"`
+	TlsMode             string `json:"tlsMode"`
+	ConfigurationMethod string `json:"tlsConfigurationMethod"`
 
 	TlsCACertFile     string `json:"tlsCaCertFile"`
 	TlsClientCertFile string `json:"tlsClientCertFile"`
@@ -122,6 +123,9 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		settings.TlsClientKey = tlsClientKey
 	}
 
+	if jsonData["tlsConfigurationMethod"] != nil {
+		settings.ConfigurationMethod = jsonData["tlsConfigurationMethod"].(string)
+	}
 	if jsonData["tlsMode"] != nil {
 		settings.TlsMode = jsonData["tlsMode"].(string)
 	}

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -54,7 +54,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 1000, "username": "john", "timeout": 10, "queryTimeout": 50, 
-											"enableSecureSocksProxy": true, "tlsMode": "verify-full",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-full", "tlsConfigurationMethod": "file-content",
 											"maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "doe", "tlsCACert": "caCert", "tlsClientCert": "clientCert", "tlsClientKey": "clientKey", "secureSocksProxyPassword": "test"},
 					},
@@ -94,7 +94,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 8812, "username": "john",
-											"enableSecureSocksProxy": true, "tlsMode": "verify-ca",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-ca", "tlsConfigurationMethod": "file-path",
 											"tlsCACertFile": "/var/caCertFile", "tlsClientCertFile": "/var/clientCertFile", "tlsClientKeyFile": "/var/clientKeyFile",
 											"timeout": 10, "queryTimeout": 50, "maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "rambo", "secureSocksProxyPassword": "test"},

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -54,7 +54,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 1000, "username": "john", "timeout": 10, "queryTimeout": 50, 
-											"enableSecureSocksProxy": true, "tlsMode": "verify-full", "tlsConfigurationMethod": "file-content",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-full",
 											"maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "doe", "tlsCACert": "caCert", "tlsClientCert": "clientCert", "tlsClientKey": "clientKey", "secureSocksProxyPassword": "test"},
 					},
@@ -73,7 +73,6 @@ func TestLoadSettings(t *testing.T) {
 					MaxIdleConnections:    100,
 					MaxConnectionLifetime: 14400,
 					TlsMode:               "verify-full",
-					ConfigurationMethod:   "file-content",
 					ProxyOptions: &proxy.Options{
 						Enabled: true,
 						Auth: &proxy.AuthOptions{
@@ -94,7 +93,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 8812, "username": "john",
-											"enableSecureSocksProxy": true, "tlsMode": "verify-ca", "tlsConfigurationMethod": "file-path",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-ca",
 											"tlsCACertFile": "/var/caCertFile", "tlsClientCertFile": "/var/clientCertFile", "tlsClientKeyFile": "/var/clientKeyFile",
 											"timeout": 10, "queryTimeout": 50, "maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "rambo", "secureSocksProxyPassword": "test"},
@@ -114,7 +113,6 @@ func TestLoadSettings(t *testing.T) {
 					MaxIdleConnections:    100,
 					MaxConnectionLifetime: 14400,
 					TlsMode:               "verify-ca",
-					ConfigurationMethod:   "file-path",
 					ProxyOptions: &proxy.Options{
 						Enabled: true,
 						Auth: &proxy.AuthOptions{

--- a/pkg/plugin/settings_test.go
+++ b/pkg/plugin/settings_test.go
@@ -54,7 +54,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 1000, "username": "john", "timeout": 10, "queryTimeout": 50, 
-											"enableSecureSocksProxy": true, "tlsMode": "verify-full", "tlsConfigurationMethod": "file-content",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-full",
 											"maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "doe", "tlsCACert": "caCert", "tlsClientCert": "clientCert", "tlsClientKey": "clientKey", "secureSocksProxyPassword": "test"},
 					},
@@ -94,7 +94,7 @@ func TestLoadSettings(t *testing.T) {
 					config: backend.DataSourceInstanceSettings{
 						UID: "ds-uid",
 						JSONData: []byte(`{ "server": "test", "port": 8812, "username": "john",
-											"enableSecureSocksProxy": true, "tlsMode": "verify-ca", "tlsConfigurationMethod": "file-path",
+											"enableSecureSocksProxy": true, "tlsMode": "verify-ca",
 											"tlsCACertFile": "/var/caCertFile", "tlsClientCertFile": "/var/clientCertFile", "tlsClientKeyFile": "/var/clientKeyFile",
 											"timeout": 10, "queryTimeout": 50, "maxOpenConnections": 100, "maxIdleConnections": 100, "maxConnectionLifetime": 14400 }`),
 						DecryptedSecureJSONData: map[string]string{"password": "rambo", "secureSocksProxyPassword": "test"},

--- a/provisioning/datasources/questdb_questdb_datasource.yaml
+++ b/provisioning/datasources/questdb_questdb_datasource.yaml
@@ -7,7 +7,6 @@ datasources:
       port: 8812
       username: admin
       tlsMode: disable
-      # tlsConfigurationMethod: file-path | file-content
       # tlsCACertFile: <string>
       # timeout: <seconds>
       # queryTimeout: <seconds>

--- a/src/components/ui/CertificationKey.tsx
+++ b/src/components/ui/CertificationKey.tsx
@@ -3,15 +3,16 @@ import { Input, Button, TextArea, Field } from '@grafana/ui';
 
 interface Props {
   label: string;
+  tooltip?: string;
   hasCert: boolean;
   placeholder: string;
   onChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-export const CertificationKey: FC<Props> = ({ hasCert, label, onChange, onClick, placeholder }) => {
+export const CertificationKey: FC<Props> = ({ hasCert, label, tooltip, onChange, onClick, placeholder }) => {
   return (
-    <Field label={label}>
+    <Field label={label} description={tooltip}>
       {hasCert ? (
         <>
           <Input type="text" disabled value="configured" width={24} />

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -24,6 +24,8 @@ export const Components = {
     TLSCACert: {
       label: 'TLS/SSL Root Certificate',
       placeholder: 'CA Cert. Begins with -----BEGIN CERTIFICATE-----',
+      tooltip:
+        "Allows you to configure certificates by specifying its content. The content will be stored encrypted in Grafana's database.",
     },
     TLSClientCert: {
       label: 'TLS/SSL Client Certificate',

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface QuestDBConfig extends DataSourceJsonData {
   maxConnectionLifetime?: number;
 
   tlsMode?: PostgresTLSModes;
+  tlsConfigurationMethod?: PostgresTLSMethods;
 
   tlsCACertFile?: string;
   tlsClientCertFile?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export enum PostgresTLSModes {
   verifyFull = 'verify-full',
 }
 
+export enum PostgresTLSMethods {
+  filePath = 'file-path',
+  fileContent = 'file-content',
+}
+
 export interface QuestDBConfig extends DataSourceJsonData {
   username: string;
   server: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,11 +9,6 @@ export enum PostgresTLSModes {
   verifyFull = 'verify-full',
 }
 
-export enum PostgresTLSMethods {
-  filePath = 'file-path',
-  fileContent = 'file-content',
-}
-
 export interface QuestDBConfig extends DataSourceJsonData {
   username: string;
   server: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,6 @@ export interface QuestDBConfig extends DataSourceJsonData {
   maxConnectionLifetime?: number;
 
   tlsMode?: PostgresTLSModes;
-  tlsConfigurationMethod?: PostgresTLSMethods;
 
   tlsCACertFile?: string;
   tlsClientCertFile?: string;

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -4,7 +4,7 @@ import { ConfigEditor } from './QuestDBConfigEditor';
 import { mockConfigEditorProps } from '../__mocks__/ConfigEditor';
 import { Components } from './../selectors';
 import '@testing-library/jest-dom';
-import { PostgresTLSMethods, PostgresTLSModes } from '../types';
+import { PostgresTLSModes } from '../types';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -62,7 +62,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).not.toBeInTheDocument();
   });
-  it('with verifyCA tlsMode', async () => {
+  it('with verifyCA tlsMode and fileContent tlsMethod', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -71,6 +71,7 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyCA,
+            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />
@@ -80,7 +81,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
   });
 
-  it('with verifyFull tlsMode', async () => {
+  it('with verifyFull tlsMode and fileContent tlsMethod', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -89,6 +90,7 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyFull,
+            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -62,7 +62,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).not.toBeInTheDocument();
   });
-  it('with verifyCA tlsMode and fileContent tlsMethod', async () => {
+  it('with verifyCA tlsMode', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -71,7 +71,6 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyCA,
-            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />
@@ -81,7 +80,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
   });
 
-  it('with verifyFull tlsMode and fileContent tlsMethod', async () => {
+  it('with verifyFull tlsMode', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -90,7 +89,6 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyFull,
-            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -4,7 +4,7 @@ import { ConfigEditor } from './QuestDBConfigEditor';
 import { mockConfigEditorProps } from '../__mocks__/ConfigEditor';
 import { Components } from './../selectors';
 import '@testing-library/jest-dom';
-import { PostgresTLSMethods, PostgresTLSModes } from '../types';
+import { PostgresTLSModes } from '../types';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');
@@ -62,7 +62,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).not.toBeInTheDocument();
   });
-  it('with verifyCA tlsMode and fileContent tlsMethod', async () => {
+  it('with verifyCA tlsMode', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -71,7 +71,6 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyCA,
-            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />
@@ -81,7 +80,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
   });
 
-  it('with verifyFull tlsMode and fileContent tlsMethod', async () => {
+  it('with verifyFull tlsMode', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -90,7 +89,6 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyFull,
-            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -4,7 +4,7 @@ import { ConfigEditor } from './QuestDBConfigEditor';
 import { mockConfigEditorProps } from '../__mocks__/ConfigEditor';
 import { Components } from './../selectors';
 import '@testing-library/jest-dom';
-import { PostgresTLSModes } from '../types';
+import { PostgresTLSMethods, PostgresTLSModes } from '../types';
 
 jest.mock('@grafana/runtime', () => {
   const original = jest.requireActual('@grafana/runtime');

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -22,7 +22,6 @@ describe('ConfigEditor', () => {
     expect(screen.getByPlaceholderText(Components.ConfigEditor.Username.placeholder)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(Components.ConfigEditor.Password.placeholder)).toBeInTheDocument();
     expect(screen.getByText(Components.ConfigEditor.TlsMode.placeholder)).toBeInTheDocument();
-    expect(screen.getByText(Components.ConfigEditor.TlsMethod.label)).toBeInTheDocument();
   });
   it('with password', async () => {
     render(
@@ -63,7 +62,7 @@ describe('ConfigEditor', () => {
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientCert.placeholder)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSClientKey.placeholder)).not.toBeInTheDocument();
   });
-  it('with tlsMode and filePath tlsMethod', async () => {
+  it('with verifyCA tlsMode and fileContent tlsMethod', async () => {
     render(
       <ConfigEditor
         {...mockConfigEditorProps()}
@@ -72,15 +71,14 @@ describe('ConfigEditor', () => {
           jsonData: {
             ...mockConfigEditorProps().options.jsonData,
             tlsMode: PostgresTLSModes.verifyCA,
-            tlsConfigurationMethod: PostgresTLSMethods.filePath,
+            tlsConfigurationMethod: PostgresTLSMethods.fileContent,
           },
         }}
       />
     );
     expect(screen.queryByText(PostgresTLSModes.verifyCA)).toBeInTheDocument();
-    expect(screen.queryByText(Components.ConfigEditor.TlsMethod.placeholder)).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACertFile.placeholder)).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACertFile.placeholder)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
   });
 
   it('with verifyFull tlsMode and fileContent tlsMethod', async () => {
@@ -98,7 +96,6 @@ describe('ConfigEditor', () => {
       />
     );
     expect(screen.queryByText(PostgresTLSModes.verifyFull)).toBeInTheDocument();
-    expect(screen.queryByText(Components.ConfigEditor.TlsMethod.placeholder)).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACertFile.placeholder)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(Components.ConfigEditor.TLSCACert.placeholder)).toBeInTheDocument();
   });

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -8,7 +8,7 @@ import {
 import { Field, Input, SecretInput, Select, Switch } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import { Components } from './../selectors';
-import { PostgresTLSModes, PostgresTLSMethods, QuestDBConfig, QuestDBSecureConfig } from './../types';
+import { PostgresTLSModes, QuestDBConfig, QuestDBSecureConfig } from './../types';
 import { gte } from 'semver';
 import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
@@ -38,15 +38,6 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       jsonData: {
         ...options.jsonData,
         tlsMode: mode,
-      },
-    });
-  };
-  const onTlsConfigurationMethodChange = (method?: PostgresTLSMethods) => {
-    onOptionsChange({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        tlsConfigurationMethod: method,
       },
     });
   };
@@ -117,11 +108,6 @@ export const ConfigEditor: React.FC<Props> = (props) => {
     { value: PostgresTLSModes.require, label: 'require' },
     { value: PostgresTLSModes.verifyCA, label: 'verify-ca' },
     { value: PostgresTLSModes.verifyFull, label: 'verify-full' },
-  ];
-
-  const tlsMethods: Array<SelectableValue<PostgresTLSMethods>> = [
-    { value: PostgresTLSMethods.filePath, label: 'File system path' },
-    { value: PostgresTLSMethods.fileContent, label: 'Certificate content' },
   ];
 
   return (
@@ -307,86 +293,34 @@ export const ConfigEditor: React.FC<Props> = (props) => {
 
         {jsonData.tlsMode && jsonData.tlsMode !== PostgresTLSModes.disable ? (
           <>
-            <Field
-              label={Components.ConfigEditor.TlsMethod.label}
-              description={Components.ConfigEditor.TlsMethod.tooltip}
-            >
-              <Select
-                options={tlsMethods}
-                value={jsonData.tlsConfigurationMethod || PostgresTLSMethods.filePath}
-                onChange={(e) => onTlsConfigurationMethodChange(e.value)}
-                placeholder={Components.ConfigEditor.TlsMethod.placeholder}
-                width={40}
+            <>
+              <CertificationKey
+                hasCert={!!hasTLSCACert}
+                onChange={(e) => onCertificateChangeFactory('tlsCACert', e.currentTarget.value)}
+                placeholder={Components.ConfigEditor.TLSCACert.placeholder}
+                label={Components.ConfigEditor.TLSCACert.label}
+                tooltip={Components.ConfigEditor.TLSCACert.tooltip}
+                onClick={() => onResetClickFactory('tlsCACert')}
               />
-            </Field>
-
-            {jsonData.tlsConfigurationMethod === PostgresTLSMethods.fileContent ? (
-              <>
-                <CertificationKey
-                  hasCert={!!hasTLSCACert}
-                  onChange={(e) => onCertificateChangeFactory('tlsCACert', e.currentTarget.value)}
-                  placeholder={Components.ConfigEditor.TLSCACert.placeholder}
-                  label={Components.ConfigEditor.TLSCACert.label}
-                  onClick={() => onResetClickFactory('tlsCACert')}
-                />
-                {false && (
-                  <>
-                    <CertificationKey
-                      hasCert={!!hasTLSClientCert}
-                      onChange={(e) => onCertificateChangeFactory('tlsClientCert', e.currentTarget.value)}
-                      placeholder={Components.ConfigEditor.TLSClientCert.placeholder}
-                      label={Components.ConfigEditor.TLSClientCert.label}
-                      onClick={() => onResetClickFactory('tlsClientCert')}
-                    />
-                    <CertificationKey
-                      hasCert={!!hasTLSClientKey}
-                      placeholder={Components.ConfigEditor.TLSClientKey.placeholder}
-                      label={Components.ConfigEditor.TLSClientKey.label}
-                      onChange={(e) => onCertificateChangeFactory('tlsClientKey', e.currentTarget.value)}
-                      onClick={() => onResetClickFactory('tlsClientKey')}
-                    />
-                  </>
-                )}
-              </>
-            ) : (
-              <>
-                <Field
-                  label={Components.ConfigEditor.TLSCACertFile.label}
-                  description={Components.ConfigEditor.TLSCACertFile.placeholder}
-                >
-                  <Input
-                    value={jsonData.tlsCACertFile || ''}
-                    onChange={onUpdateDatasourceJsonDataOption(props, 'tlsCACertFile')}
-                    width={40}
-                    placeholder={Components.ConfigEditor.TLSCACertFile.placeholder}
+              {false && (
+                <>
+                  <CertificationKey
+                    hasCert={!!hasTLSClientCert}
+                    onChange={(e) => onCertificateChangeFactory('tlsClientCert', e.currentTarget.value)}
+                    placeholder={Components.ConfigEditor.TLSClientCert.placeholder}
+                    label={Components.ConfigEditor.TLSClientCert.label}
+                    onClick={() => onResetClickFactory('tlsClientCert')}
                   />
-                </Field>
-                {false && (
-                  <>
-                    <Field
-                      label={Components.ConfigEditor.TLSClientCertFile.label}
-                      description={Components.ConfigEditor.TLSClientCertFile.placeholder}
-                    >
-                      <Input
-                        value={jsonData.tlsClientCertFile || ''}
-                        onChange={onUpdateDatasourceJsonDataOption(props, 'tlsClientCertFile')}
-                        width={40}
-                      />
-                    </Field>
-                    <Field
-                      label={Components.ConfigEditor.TLSClientKeyFile.label}
-                      description={Components.ConfigEditor.TLSClientKeyFile.placeholder}
-                    >
-                      <Input
-                        value={jsonData.tlsClientKeyFile || ''}
-                        onChange={onUpdateDatasourceJsonDataOption(props, 'tlsClientKeyFile')}
-                        width={40}
-                      />
-                    </Field>
-                  </>
-                )}
-              </>
-            )}
+                  <CertificationKey
+                    hasCert={!!hasTLSClientKey}
+                    placeholder={Components.ConfigEditor.TLSClientKey.placeholder}
+                    label={Components.ConfigEditor.TLSClientKey.label}
+                    onChange={(e) => onCertificateChangeFactory('tlsClientKey', e.currentTarget.value)}
+                    onClick={() => onResetClickFactory('tlsClientKey')}
+                  />
+                </>
+              )}
+            </>
           </>
         ) : null}
       </ConfigSection>


### PR DESCRIPTION
Since the plugin should not use the file system in the way of links, the only viable option to set SSL certificate is to paste its contents into a textarea. This PR removes the concept of `tlsConfigurationMethod` in the datasource configuration UI.