### PR TITLE
Enable build provenance attestation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,19 @@ on:
     tags:
       - "v*" # Run workflow on version tags, e.g. v1.0.0.
 
-# necessary to create releases
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: grafana/plugin-actions/build-plugin@main
         with:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          attestation: true


### PR DESCRIPTION
## Summary
- Add `id-token: write` and `attestations: write` permissions to the release job
- Enable `attestation: true` in `grafana/plugin-actions/build-plugin`
- Upgrade `actions/checkout` from v3 to v4

This adds cryptographic build provenance attestation, so Grafana can verify the plugin zip was built from this repo's CI. No GitHub repo settings changes needed - permissions are declared in the workflow file.

Addresses the `invalid-provenance-attestation` recommendation from Grafana's plugin validation.