### PR TITLE
Fix credential logging and enable build attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,19 @@ on:
     tags:
       - "v*" # Run workflow on version tags, e.g. v1.0.0.
 
-# necessary to create releases
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: grafana/plugin-actions/build-plugin@main
         with:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          attestation: true

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -58,7 +58,10 @@ func (h *QuestDB) Connect(ctx context.Context, config backend.DataSourceInstance
 		return nil, err
 	}
 
-	log.DefaultLogger.Error("QuestDB connection string", "str", connstr)
+	log.DefaultLogger.Debug("QuestDB connection string generated",
+		"server", settings.Server,
+		"port", settings.Port,
+		"tlsMode", settings.TlsMode)
 
 	connector, err := pq.NewConnector(connstr)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Remove ERROR-level log that exposed the full connection string (including user/password), replace with DEBUG-level log showing only server, port, and TLS mode
- Enable build provenance attestation in release workflow (adds id-token:write and attestations:write permissions, sets attestation: true)
- Upgrade actions/checkout from v3 to v4

## Context
The credential fix was requested by the Grafana plugin review team before v0.1.7 can be approved. The attestation change addresses the `invalid-provenance-attestation` recommendation from Grafana's plugin validation.