### PR TITLE
feat: per-user/per-group QuestDB service-account routing for memory limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Unreleased
+
+## Added
+
+- Per-user QuestDB service-account routing: optionally assume a per-user/per-group service
+  account on each query so QuestDB Enterprise memory limits apply per Grafana user. Disabled
+  by default; behavior is unchanged when off. See the "Per-user service accounts" section in
+  the README.
+
 ## 0.1.4
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,11 @@ and this project adheres to
 
 ## Added
 
-- Per-user QuestDB service-account routing: optionally assume a per-user/per-group service
-  account on each query so QuestDB Enterprise memory limits apply per Grafana user. Disabled
-  by default; behavior is unchanged when off. See the "Per-user service accounts" section in
-  the README.
-- Optional OIDC/Okta group routing for the above: map a user's ID-token group (forwarded via
-  Grafana's "Forward OAuth Identity") to a service account, with username > group > default
-  precedence. Additive and opt-in; no effect unless group mappings are configured.
+- Per-user QuestDB service-account routing: optionally assume a per-user or per-group service
+  account on each query so QuestDB Enterprise memory limits apply per Grafana user. Groups are
+  read from an OIDC/Okta ID token forwarded via Grafana's "Forward OAuth Identity", with
+  username > group > default precedence. Disabled by default; behavior is unchanged when off.
+  See the "Per-user service accounts" section in the README.
 
 ## 0.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
   account on each query so QuestDB Enterprise memory limits apply per Grafana user. Disabled
   by default; behavior is unchanged when off. See the "Per-user service accounts" section in
   the README.
+- Optional OIDC/Okta group routing for the above: map a user's ID-token group (forwarded via
+  Grafana's "Forward OAuth Identity") to a service account, with username > group > default
+  precedence. Additive and opt-in; no effect unless group mappings are configured.
 
 ## 0.1.4
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ too and grant it only the service accounts used here. Note that one connection p
 created per active service account (each using the configured connection limits), so favor
 groups over a unique account per user.
 
+**Save & Test** validates the routing configuration: it rejects a malformed service-account
+name and, when a default service account is set, opens a routed connection and runs `ASSUME
+SERVICE ACCOUNT` against it — so a missing `GRANT ASSUME …` or a non-existent account is
+caught at config time rather than failing every routed query later. Per-user and per-group
+accounts are name-checked but not individually probed (there is no specific requesting user
+at config time), so verify those grants separately.
+
 #### Per-group routing via OIDC groups (Okta)
 
 > Builds on the feature above and is likewise **opt-in**. With no group mappings configured,

--- a/README.md
+++ b/README.md
@@ -146,8 +146,11 @@ service account). The same can be provisioned via `jsonData`:
 This is resource governance, not a hard security boundary: the SQL editor lets a user run
 arbitrary SQL, including `EXIT SERVICE ACCOUNT;`, so set a memory limit on the base login
 too and grant it only the service accounts used here. Note that one connection pool is
-created per active service account (each using the configured connection limits), so favor
-groups over a unique account per user.
+created per active service account. `maxOpenConnections` applies **per pool** and defaults
+to `0` (unlimited), so with routing on the footprint is one unlimited pool per active
+account, not the single pool used when routing is off. Set `maxOpenConnections` to a sane
+per-pool value and favor groups over a unique account per user, so the total connection
+count stays bounded against QuestDB's PGWire connection limit.
 
 **Save & Test** validates the routing configuration: it rejects a malformed service-account
 name and, when a default service account is set, opens a routed connection and runs `ASSUME
@@ -175,9 +178,9 @@ wins. Matching is case-insensitive. Groups are read from the `groups` claim by d
 override the claim name with `groupsClaim` if your IdP uses a different one.
 
 **Okta**: add a `groups` claim to the OIDC app's **ID token** (Sign On → OpenID Connect ID
-Token → Edit), scoped to the groups you map. **Grafana**: enable **Forward OAuth Identity**
-on the data source, then under **Per-user service accounts** add **Group mappings** (group →
-service account). Provisioned via `jsonData`:
+Token → Edit), scoped to the groups you map. **Grafana**: under **Per-user service accounts**
+enable **Forward OAuth Identity** and add **Group mappings** (group → service account).
+Provisioned via `jsonData`:
 
 ```yaml
     jsonData:

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ ASSUME SERVICE ACCOUNT <serviceAccount>;
 
 Because an Enterprise service account can carry a memory limit, and a user assuming a
 service account picks up that account's limit, this transparently caps the memory of that
-user's queries. Grouping is expressed on the QuestDB side: map several Grafana users to
-the same service account, and/or set the limit on a QuestDB group of service accounts.
+user's queries. Users can be grouped two ways: map several Grafana users — or whole
+**OIDC/Okta groups** (see [Per-group routing](#per-group-routing-via-oidc-groups-okta)
+below) — to the same service account, and/or set the limit on a QuestDB group of service
+accounts.
 
 The Grafana user is taken from the backend-verified identity (`PluginContext.User.Login`),
 so it cannot be tampered with from the query payload. Matching is case-insensitive.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,47 @@ too and grant it only the service accounts used here. Note that one connection p
 created per active service account (each using the configured connection limits), so favor
 groups over a unique account per user.
 
+#### Per-group routing via OIDC groups (Okta)
+
+> Builds on the feature above and is likewise **opt-in**. With no group mappings configured,
+> behavior is exactly the per-user feature's.
+
+When users log in through **OIDC / Generic OAuth** (e.g. Okta), the plugin can map a user's
+**group** to a service account, so a memory limit on that account caps everyone in the group
+without enumerating usernames. This requires **Forward OAuth Identity**
+(`jsonData.oauthPassThru: true`) on the data source: Grafana then forwards the user's ID
+token (as the `X-Id-Token` header) and the plugin reads the groups from it. The token is
+injected by the Grafana server from the user's session, so — like the username — the group
+identity cannot be forged from the query payload.
+
+Resolution is most-specific-first: **user mapping → group mapping → default service
+account**. When a user belongs to several mapped groups, the **first matching row (top-down)**
+wins. Matching is case-insensitive. Groups are read from the `groups` claim by default;
+override the claim name with `groupsClaim` if your IdP uses a different one.
+
+**Okta**: add a `groups` claim to the OIDC app's **ID token** (Sign On → OpenID Connect ID
+Token → Edit), scoped to the groups you map. **Grafana**: enable **Forward OAuth Identity**
+on the data source, then under **Per-user service accounts** add **Group mappings** (group →
+service account). Provisioned via `jsonData`:
+
+```yaml
+    jsonData:
+      oauthPassThru: true                 # Forward OAuth Identity (core Grafana setting)
+      serviceAccountRoutingEnabled: true
+      defaultServiceAccount: sa_default
+      groupsClaim: groups                 # optional; defaults to "groups"
+      serviceAccountGroupMappings:
+        - group: Analysts
+          serviceAccount: sa_analysts
+        - group: Execs
+          serviceAccount: sa_execs
+```
+
+SAML logins do not mint an OIDC ID token, so this route is unavailable there; those users
+fall back to username mappings and the default service account. The groups claim is read for
+governance without verifying the token's signature or expiry, so do not treat it as a hard
+security boundary (the `EXIT SERVICE ACCOUNT` caveat above still applies).
+
 ## Building queries
 
 The query editor allows you to query QuestDB to return time series or

--- a/README.md
+++ b/README.md
@@ -88,6 +88,65 @@ datasources:
 If you are using QuestDB Enterprise and have enabled TLS, you would need to change
 `tlsMode: require` in the example above.
 
+### Per-user service accounts (memory limits)
+
+> Requires QuestDB **Enterprise**. With the feature disabled (the default) the plugin
+> behaves exactly as before and works against Open Source.
+
+A single, shared data source can apply **per-Grafana-user memory limits** to the queries
+each user runs. The data source still authenticates with one common login; when a query
+runs, the plugin makes the QuestDB session assume a service account specific to the
+requesting Grafana user (or shared by a group of users):
+
+```sql
+ASSUME SERVICE ACCOUNT <serviceAccount>;
+```
+
+Because an Enterprise service account can carry a memory limit, and a user assuming a
+service account picks up that account's limit, this transparently caps the memory of that
+user's queries. Grouping is expressed on the QuestDB side: map several Grafana users to
+the same service account, and/or set the limit on a QuestDB group of service accounts.
+
+The Grafana user is taken from the backend-verified identity (`PluginContext.User.Login`),
+so it cannot be tampered with from the query payload. Matching is case-insensitive.
+Unmapped users and backend-initiated queries (alerting, reporting) use the configured
+default service account; if no default is set, they run as the base login. A mapping row
+with a blank service account is ignored — that user falls back to the default rather than
+running uncapped.
+
+**QuestDB setup** (example: analysts capped at 2G, with `baseuser` as the data source login):
+
+```sql
+CREATE SERVICE ACCOUNT sa_analysts;
+GRANT SELECT ON ALL TABLES TO sa_analysts;
+ALTER SERVICE ACCOUNT sa_analysts SET MEMORY LIMIT 2G;
+GRANT ASSUME SERVICE ACCOUNT sa_analysts TO baseuser;
+
+-- defense in depth: also bound the base login
+ALTER USER baseuser SET MEMORY LIMIT 256M;
+```
+
+**Grafana setup**: in the data source config, open **Per-user service accounts**, enable
+the toggle, set a **Default service account**, and add **User mappings** (Grafana login →
+service account). The same can be provisioned via `jsonData`:
+
+```yaml
+    jsonData:
+      serviceAccountRoutingEnabled: true
+      defaultServiceAccount: sa_default
+      serviceAccountMappings:
+        - grafanaUser: johndoe
+          serviceAccount: sa_analysts
+        - grafanaUser: ceo
+          serviceAccount: sa_execs
+```
+
+This is resource governance, not a hard security boundary: the SQL editor lets a user run
+arbitrary SQL, including `EXIT SERVICE ACCOUNT;`, so set a memory limit on the base login
+too and grant it only the service accounts used here. Note that one connection pool is
+created per active service account (each using the configured connection limits), so favor
+groups over a unique account per user.
+
 ## Building queries
 
 The query editor allows you to query QuestDB to return time series or

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -21,5 +21,10 @@ func main() {
 
 func newDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	ds := sqlds.NewDatasource(&plugin.QuestDB{})
+	// Enables per-service-account connection pools for service-account routing. Safe to
+	// set unconditionally: when routing is off (or a query carries no connectionArgs),
+	// sqlds returns the default pool, so behavior is identical to before. ForwardHeaders
+	// is intentionally left off so HTTP headers are not folded into the pool cache key.
+	ds.EnableMultipleConnections = true
 	return ds.NewDatasource(ctx, settings)
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -20,7 +20,8 @@ func main() {
 }
 
 func newDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	ds := sqlds.NewDatasource(&plugin.QuestDB{})
+	driver := &plugin.QuestDB{}
+	ds := sqlds.NewDatasource(driver)
 	// Per-service-account connection pools are only needed when routing is enabled, so we
 	// gate this on the routing flag. Leaving it off for routing-disabled data sources keeps
 	// the prior single-pool behavior, where a query carrying connectionArgs is rejected
@@ -28,6 +29,21 @@ func newDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	// MutateQueryData owns connectionArgs (it strips any client value), so the number of
 	// distinct pools is bounded by the configured service accounts. ForwardHeaders is
 	// intentionally left off so HTTP headers are not folded into the pool cache key.
+	//
+	// Caveat (upstream, not plugin-fixable): enabling multiple connections activates a race
+	// in sqlds Connector.GetConnectionFromQuery — a non-atomic load→Connect→store on a
+	// sync.Map (no LoadOrStore). Concurrent first-use of the same service account (e.g. a
+	// dashboard whose panels fire together for a freshly-mapped user) can open several pools
+	// and orphan all but the last; Dispose only closes pools still in the map, so the losers
+	// leak their connections. The window is one-time per account per instance (subsequent
+	// uses hit the cache). To shrink it, favor a small set of group-mapped accounts over many
+	// per-user accounts, and set a connection max-lifetime so any orphaned idle connection is
+	// eventually reaped rather than held for the life of the process.
 	ds.EnableMultipleConnections = plugin.LoadServiceAccountSettings(settings).ServiceAccountRoutingEnabled
+	// Base Save & Test only checks base-login connectivity. PostCheckHealth additionally
+	// exercises the routing path (validates configured account names and runs a real ASSUME
+	// for the default account) so routing misconfiguration fails here instead of on every
+	// routed query. It is a no-op when routing is disabled.
+	ds.PostCheckHealth = driver.PostCheckHealth
 	return ds.NewDatasource(ctx, settings)
 }

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -21,10 +21,13 @@ func main() {
 
 func newDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	ds := sqlds.NewDatasource(&plugin.QuestDB{})
-	// Enables per-service-account connection pools for service-account routing. Safe to
-	// set unconditionally: when routing is off (or a query carries no connectionArgs),
-	// sqlds returns the default pool, so behavior is identical to before. ForwardHeaders
-	// is intentionally left off so HTTP headers are not folded into the pool cache key.
-	ds.EnableMultipleConnections = true
+	// Per-service-account connection pools are only needed when routing is enabled, so we
+	// gate this on the routing flag. Leaving it off for routing-disabled data sources keeps
+	// the prior single-pool behavior, where a query carrying connectionArgs is rejected
+	// rather than spawning cached pools keyed by client-supplied args. When routing is on,
+	// MutateQueryData owns connectionArgs (it strips any client value), so the number of
+	// distinct pools is bounded by the configured service accounts. ForwardHeaders is
+	// intentionally left off so HTTP headers are not folded into the pool cache key.
+	ds.EnableMultipleConnections = plugin.LoadServiceAccountSettings(settings).ServiceAccountRoutingEnabled
 	return ds.NewDatasource(ctx, settings)
 }

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -369,7 +369,17 @@ func (h *QuestDB) PostCheckHealth(ctx context.Context, req *backend.CheckHealthR
 	if dsi == nil {
 		return nil
 	}
-	settings := LoadServiceAccountSettings(*dsi)
+	// Parse directly (rather than via LoadServiceAccountSettings) so a malformed routing block
+	// is rejected here. A provisioned type mismatch unmarshals partially: the offending row is
+	// dropped/blanked, or — when the enable flag itself fails to parse — routing silently reads
+	// as "off". Either way the affected user would run on the uncapped base login with no
+	// signal, so it must fail Save & Test. Checked before the enabled short-circuit precisely
+	// to catch a mistyped enable flag. validateServiceAccountNames (below) cannot see a row the
+	// parser already dropped, so the raw parse error is surfaced too.
+	var settings Settings
+	if err := applyServiceAccountSettings(&settings, dsi.JSONData); err != nil {
+		return routingHealthError(fmt.Sprintf("could not parse routing configuration: %v", err))
+	}
 	if !settings.ServiceAccountRoutingEnabled {
 		return nil
 	}

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -291,7 +292,13 @@ func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataReq
 	if !settings.ServiceAccountRoutingEnabled {
 		return ctx, req
 	}
-	sa := settings.resolveServiceAccount(req.PluginContext.User)
+	// Resolve OIDC groups from the forwarded ID token only when group routing is actually
+	// configured, so the (PII-bearing) token is never touched unless it is needed.
+	var groups []string
+	if len(settings.ServiceAccountGroupMappings) > 0 {
+		groups = extractGroups(req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName), settings.GroupsClaim)
+	}
+	sa := settings.resolveServiceAccount(req.PluginContext.User, groups)
 	if sa == "" {
 		return ctx, req // base pool, no ASSUME
 	}
@@ -320,6 +327,54 @@ func withConnectionArgs(queryJSON, connArgs json.RawMessage) json.RawMessage {
 		return queryJSON
 	}
 	return out
+}
+
+// extractGroups decodes the groups claim from a forwarded OAuth/OIDC ID token (the
+// X-Id-Token header that Grafana attaches when "Forward OAuth Identity" is on). The token
+// is injected by the Grafana server from the user's session, so it is trustworthy for
+// governance; per the design we read the claim WITHOUT verifying its signature or expiry
+// (which also sidesteps Grafana occasionally forwarding an expired token). It returns nil
+// — never an error — for a token that is absent, malformed, or whose claim is missing or
+// is not a JSON array of strings, so resolution falls through to the default account. The
+// claim name defaults to "groups" (the Okta default) when not configured.
+func extractGroups(idToken, claim string) []string {
+	if idToken == "" {
+		return nil
+	}
+	if claim == "" {
+		claim = "groups"
+	}
+	// A JWT is header.payload.signature, each base64url-encoded; only the payload is needed.
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := decodeJWTSegment(parts[1])
+	if err != nil {
+		return nil
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil
+	}
+	raw, ok := claims[claim]
+	if !ok {
+		return nil
+	}
+	var groups []string
+	if err := json.Unmarshal(raw, &groups); err != nil {
+		return nil // claim present but not a string array
+	}
+	return groups
+}
+
+// decodeJWTSegment base64url-decodes a single JWT segment, tolerating both the canonical
+// unpadded form and padded variants.
+func decodeJWTSegment(seg string) ([]byte, error) {
+	if m := len(seg) % 4; m != 0 {
+		seg += strings.Repeat("=", 4-m)
+	}
+	return base64.URLEncoding.DecodeString(seg)
 }
 
 // MutateResponse For any view other than traces we convert FieldTypeNullableJSON to string

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -344,6 +344,74 @@ func withConnectionArgs(queryJSON, connArgs json.RawMessage) json.RawMessage {
 	return out
 }
 
+// assumeProbeTimeout bounds the routed health-check probe so a slow or hung ASSUME on a
+// misconfigured server cannot stall Save & Test indefinitely.
+const assumeProbeTimeout = 30 * time.Second
+
+// PostCheckHealth runs at Save & Test time, after sqlds has already verified base-login
+// connectivity against the default pool. That base check never exercises service-account
+// routing: it connects with no connectionArgs, so no ASSUME runs. A misconfiguration in
+// the routing path — a malformed account name, a missing
+// `GRANT ASSUME SERVICE ACCOUNT … TO <login>`, or a non-existent default account — would
+// therefore pass Save & Test and only surface later as a failure on every routed query.
+//
+// To close that gap, when routing is enabled this:
+//  1. validates every configured account name syntactically (cheap, no DB round-trip), and
+//  2. opens a routed pool for the default account and pings it, so the ASSUME actually runs
+//     against the live server.
+//
+// Per-user/per-group accounts are validated in step 1 but not live-probed: there is no
+// specific requesting user at config time, so only the default account is exercised
+// end-to-end. Returns nil (healthy) when routing is disabled or there is no default account
+// to probe; a non-nil error result fails Save & Test with an actionable message.
+func (h *QuestDB) PostCheckHealth(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
+	dsi := req.PluginContext.DataSourceInstanceSettings
+	if dsi == nil {
+		return nil
+	}
+	settings := LoadServiceAccountSettings(*dsi)
+	if !settings.ServiceAccountRoutingEnabled {
+		return nil
+	}
+	if err := settings.validateServiceAccountNames(); err != nil {
+		return routingHealthError(err.Error())
+	}
+	sa := strings.TrimSpace(settings.DefaultServiceAccount)
+	if sa == "" {
+		// Only per-user/per-group mappings are configured; their names are validated above,
+		// but there is no default account to exercise end-to-end here.
+		return nil
+	}
+	msg, err := json.Marshal(connectionArgs{ServiceAccount: sa})
+	if err != nil {
+		return routingHealthError(err.Error())
+	}
+	db, err := h.Connect(ctx, *dsi, msg)
+	if err != nil {
+		return routingHealthError(err.Error())
+	}
+	defer db.Close()
+	// PingContext forces a physical connection, which is what actually runs the ASSUME via
+	// assumeServiceAccountConnector; a bare OpenDB is lazy and would prove nothing.
+	probeCtx, cancel := context.WithTimeout(ctx, assumeProbeTimeout)
+	defer cancel()
+	if err := db.PingContext(probeCtx); err != nil {
+		return routingHealthError(fmt.Sprintf(
+			"cannot assume the default service account %q: %v; ensure it exists and that the data source login has been granted ASSUME SERVICE ACCOUNT %s",
+			sa, err, sa))
+	}
+	return nil
+}
+
+// routingHealthError builds a failed health-check result tagged so the operator can tell the
+// failure came from the service-account routing probe rather than base connectivity.
+func routingHealthError(msg string) *backend.CheckHealthResult {
+	return &backend.CheckHealthResult{
+		Status:  backend.HealthStatusError,
+		Message: "Service-account routing: " + msg,
+	}
+}
+
 // extractGroups decodes the groups claim from a forwarded OAuth/OIDC ID token (the
 // X-Id-Token header that Grafana attaches when "Forward OAuth Identity" is on). The token
 // is injected by the Grafana server from the user's session, so it is trustworthy for

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -298,14 +298,20 @@ func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataReq
 	if len(settings.ServiceAccountGroupMappings) > 0 {
 		groups = extractGroups(req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName), settings.GroupsClaim)
 	}
-	sa := settings.resolveServiceAccount(req.PluginContext.User, groups)
-	if sa == "" {
-		return ctx, req // base pool, no ASSUME
-	}
-	connArgs, err := json.Marshal(connectionArgs{ServiceAccount: sa})
-	if err != nil {
-		log.DefaultLogger.Error("QuestDB failed to marshal connectionArgs", "error", err)
-		return ctx, req
+	// When routing is enabled connectionArgs is plugin-owned: stamp the resolved account,
+	// or strip any client-supplied connectionArgs when the user resolves to no account, so
+	// the service account stays server-resolved from a verified identity and a query payload
+	// can never select its own account (and thus its own memory limit).
+	var connArgs json.RawMessage
+	if sa := settings.resolveServiceAccount(req.PluginContext.User, groups); sa != "" {
+		marshaled, err := json.Marshal(connectionArgs{ServiceAccount: sa})
+		if err != nil {
+			// Marshaling a single validated string should never fail; if it somehow does,
+			// fall through with connArgs == nil so the client value is stripped (fail closed).
+			log.DefaultLogger.Error("QuestDB failed to marshal connectionArgs", "error", err)
+		} else {
+			connArgs = marshaled
+		}
 	}
 	for i := range req.Queries {
 		req.Queries[i].JSON = withConnectionArgs(req.Queries[i].JSON, connArgs)
@@ -313,15 +319,24 @@ func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataReq
 	return ctx, req
 }
 
-// withConnectionArgs merges "connectionArgs": <connArgs> into a query JSON object,
-// preserving existing fields (rawSql, format, ...). On malformed JSON it returns the
-// input unchanged.
+// withConnectionArgs sets the "connectionArgs" field of a query JSON object to connArgs,
+// preserving all other fields (rawSql, format, ...). A nil connArgs instead removes the
+// field — this is how a client-supplied value is stripped when the user resolves to no
+// service account (the field is left untouched when there is nothing to strip). On
+// malformed (non-object) JSON it returns the input unchanged.
 func withConnectionArgs(queryJSON, connArgs json.RawMessage) json.RawMessage {
 	m := map[string]json.RawMessage{}
 	if err := json.Unmarshal(queryJSON, &m); err != nil {
 		return queryJSON
 	}
-	m["connectionArgs"] = connArgs
+	if connArgs == nil {
+		if _, ok := m["connectionArgs"]; !ok {
+			return queryJSON // nothing to strip; leave the bytes untouched
+		}
+		delete(m, "connectionArgs")
+	} else {
+		m["connectionArgs"] = connArgs
+	}
 	out, err := json.Marshal(m)
 	if err != nil {
 		return queryJSON
@@ -368,13 +383,10 @@ func extractGroups(idToken, claim string) []string {
 	return groups
 }
 
-// decodeJWTSegment base64url-decodes a single JWT segment, tolerating both the canonical
-// unpadded form and padded variants.
+// decodeJWTSegment base64url-decodes a single JWT segment. JWT segments use canonical
+// unpadded base64url; TrimRight tolerates accidentally-padded variants too.
 func decodeJWTSegment(seg string) ([]byte, error) {
-	if m := len(seg) % 4; m != 0 {
-		seg += strings.Repeat("=", 4-m)
-	}
-	return base64.URLEncoding.DecodeString(seg)
+	return base64.RawURLEncoding.DecodeString(strings.TrimRight(seg, "="))
 }
 
 // MutateResponse For any view other than traces we convert FieldTypeNullableJSON to string

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -292,18 +292,18 @@ func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataReq
 	if !settings.ServiceAccountRoutingEnabled {
 		return ctx, req
 	}
-	// Resolve OIDC groups from the forwarded ID token only when group routing is actually
-	// configured, so the (PII-bearing) token is never touched unless it is needed.
-	var groups []string
-	if len(settings.ServiceAccountGroupMappings) > 0 {
-		groups = extractGroups(req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName), settings.GroupsClaim)
-	}
 	// When routing is enabled connectionArgs is plugin-owned: stamp the resolved account,
 	// or strip any client-supplied connectionArgs when the user resolves to no account, so
 	// the service account stays server-resolved from a verified identity and a query payload
-	// can never select its own account (and thus its own memory limit).
+	// can never select its own account (and thus its own memory limit). The OIDC groups are
+	// pulled from the forwarded ID token lazily — resolveServiceAccount calls groupsFn only
+	// if it reaches the group step — so the (PII-bearing) token is never decoded for a user a
+	// username mapping already covers, nor when no group mappings are configured.
 	var connArgs json.RawMessage
-	if sa := settings.resolveServiceAccount(req.PluginContext.User, groups); sa != "" {
+	groupsFn := func() []string {
+		return extractGroups(req.GetHTTPHeader(backend.OAuthIdentityIDTokenHeaderName), settings.GroupsClaim)
+	}
+	if sa := settings.resolveServiceAccountLazy(req.PluginContext.User, groupsFn); sa != "" {
 		marshaled, err := json.Marshal(connectionArgs{ServiceAccount: sa})
 		if err != nil {
 			// Marshaling a single validated string should never fail; if it somehow does,
@@ -430,7 +430,8 @@ func routingHealthError(msg string) *backend.CheckHealthResult {
 // governance; per the design we read the claim WITHOUT verifying its signature or expiry
 // (which also sidesteps Grafana occasionally forwarding an expired token). It returns nil
 // — never an error — for a token that is absent, malformed, or whose claim is missing or
-// is not a JSON array of strings, so resolution falls through to the default account; a
+// is neither a JSON string nor an array of strings, so resolution falls through to the
+// default account; a
 // present-but-unusable token is logged at Debug (an absent one is the normal no-forwarding
 // case and is not). The claim name defaults to "groups" (the Okta default) when not configured.
 func extractGroups(idToken, claim string) []string {
@@ -466,11 +467,18 @@ func extractGroups(idToken, claim string) []string {
 		return nil
 	}
 	var groups []string
-	if err := json.Unmarshal(raw, &groups); err != nil {
-		log.DefaultLogger.Debug("QuestDB groups claim is not a JSON array of strings; using default account", "claim", claim)
-		return nil // claim present but not a string array
+	if err := json.Unmarshal(raw, &groups); err == nil {
+		return groups
 	}
-	return groups
+	// Some IdPs serialize a single group as a scalar string ("groups":"Analysts") rather than
+	// a one-element array; accept that form too so those users still match a group mapping
+	// instead of silently falling through to the default account.
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}
+	}
+	log.DefaultLogger.Debug("QuestDB groups claim is neither a string nor an array of strings; using default account", "claim", claim)
+	return nil // claim present but not a string or string array
 }
 
 // decodeJWTSegment base64url-decodes a single JWT segment. JWT segments use canonical

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -430,8 +430,9 @@ func routingHealthError(msg string) *backend.CheckHealthResult {
 // governance; per the design we read the claim WITHOUT verifying its signature or expiry
 // (which also sidesteps Grafana occasionally forwarding an expired token). It returns nil
 // — never an error — for a token that is absent, malformed, or whose claim is missing or
-// is not a JSON array of strings, so resolution falls through to the default account. The
-// claim name defaults to "groups" (the Okta default) when not configured.
+// is not a JSON array of strings, so resolution falls through to the default account; a
+// present-but-unusable token is logged at Debug (an absent one is the normal no-forwarding
+// case and is not). The claim name defaults to "groups" (the Okta default) when not configured.
 func extractGroups(idToken, claim string) []string {
 	if idToken == "" {
 		return nil
@@ -440,24 +441,33 @@ func extractGroups(idToken, claim string) []string {
 		claim = "groups"
 	}
 	// A JWT is header.payload.signature, each base64url-encoded; only the payload is needed.
+	// A present-but-unusable token (e.g. an encrypted 5-segment JWE, which some Okta/Azure
+	// setups issue) otherwise routes every group-mapped user to the default account silently;
+	// log the fallback at Debug so it is diagnosable. The messages omit the token, payload, and
+	// parse-error text, any of which can carry the token's contents.
 	parts := strings.Split(idToken, ".")
 	if len(parts) != 3 {
+		log.DefaultLogger.Debug("QuestDB ignoring forwarded ID token for group routing: not a 3-segment JWT (encrypted JWE tokens are unsupported); using default account", "segments", len(parts))
 		return nil
 	}
 	payload, err := decodeJWTSegment(parts[1])
 	if err != nil {
+		log.DefaultLogger.Debug("QuestDB ignoring forwarded ID token for group routing: payload is not valid base64url; using default account")
 		return nil
 	}
 	var claims map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &claims); err != nil {
+		log.DefaultLogger.Debug("QuestDB ignoring forwarded ID token for group routing: payload is not valid JSON; using default account")
 		return nil
 	}
 	raw, ok := claims[claim]
 	if !ok {
+		log.DefaultLogger.Debug("QuestDB groups claim not present in forwarded ID token; using default account", "claim", claim)
 		return nil
 	}
 	var groups []string
 	if err := json.Unmarshal(raw, &groups); err != nil {
+		log.DefaultLogger.Debug("QuestDB groups claim is not a JSON array of strings; using default account", "claim", claim)
 		return nil // claim present but not a string array
 	}
 	return groups

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -97,7 +98,26 @@ func (h *QuestDB) Connect(ctx context.Context, config backend.DataSourceInstance
 		}
 	}
 
-	db := sql.OpenDB(connector)
+	// When service-account routing is enabled, sqlds creates one pool per distinct
+	// connectionArgs. The message carries the service account stamped by MutateQueryData;
+	// we wrap the connector so each new physical connection assumes that account exactly
+	// once. The account's memory limit then applies to every query on this pool.
+	var conn driver.Connector = connector
+	if settings.ServiceAccountRoutingEnabled && len(message) > 0 {
+		var args connectionArgs
+		if err := json.Unmarshal(message, &args); err == nil && args.ServiceAccount != "" {
+			stmt, err := buildAssumeStatement(args.ServiceAccount)
+			if err != nil {
+				log.DefaultLogger.Error("QuestDB invalid service account name", "error", err)
+				return nil, err
+			}
+			conn = &assumeServiceAccountConnector{base: connector, stmt: stmt}
+			log.DefaultLogger.Debug("QuestDB service account routing enabled for pool",
+				"serviceAccount", args.ServiceAccount)
+		}
+	}
+
+	db := sql.OpenDB(conn)
 	db.SetMaxOpenConns(int(settings.MaxOpenConnections))
 	db.SetMaxIdleConns(int(settings.MaxIdleConnections))
 	db.SetConnMaxLifetime(time.Duration(settings.MaxConnectionLifetime) * time.Second)
@@ -248,10 +268,93 @@ func (h *QuestDB) MutateQuery(ctx context.Context, req backend.DataQuery) (conte
 	return ctx, req
 }
 
+// connectionArgs is the per-query routing payload carried in the query's connectionArgs
+// field. sqlds keys a separate connection pool per distinct connectionArgs value, which
+// is how we get one pool (and thus one ASSUME) per service account.
+type connectionArgs struct {
+	ServiceAccount string `json:"serviceAccount"`
+}
+
+// MutateQueryData resolves the requesting Grafana user to a service account (when
+// routing is enabled) and stamps it into every query's connectionArgs, so sqlds routes
+// the queries to the matching per-service-account connection pool. When routing is off,
+// or the user resolves to no service account, the request is returned unchanged and the
+// queries run on the default (base login) pool.
+func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataRequest) (context.Context, *backend.QueryDataRequest) {
+	dsi := req.PluginContext.DataSourceInstanceSettings
+	if dsi == nil {
+		return ctx, req
+	}
+	// Resolve routing from non-secret jsonData only; this must not depend on credentials
+	// being present in the request's PluginContext.
+	settings := LoadServiceAccountSettings(*dsi)
+	if !settings.ServiceAccountRoutingEnabled {
+		return ctx, req
+	}
+	sa := settings.resolveServiceAccount(req.PluginContext.User)
+	if sa == "" {
+		return ctx, req // base pool, no ASSUME
+	}
+	connArgs, err := json.Marshal(connectionArgs{ServiceAccount: sa})
+	if err != nil {
+		log.DefaultLogger.Error("QuestDB failed to marshal connectionArgs", "error", err)
+		return ctx, req
+	}
+	for i := range req.Queries {
+		req.Queries[i].JSON = withConnectionArgs(req.Queries[i].JSON, connArgs)
+	}
+	return ctx, req
+}
+
+// withConnectionArgs merges "connectionArgs": <connArgs> into a query JSON object,
+// preserving existing fields (rawSql, format, ...). On malformed JSON it returns the
+// input unchanged.
+func withConnectionArgs(queryJSON, connArgs json.RawMessage) json.RawMessage {
+	m := map[string]json.RawMessage{}
+	if err := json.Unmarshal(queryJSON, &m); err != nil {
+		return queryJSON
+	}
+	m["connectionArgs"] = connArgs
+	out, err := json.Marshal(m)
+	if err != nil {
+		return queryJSON
+	}
+	return out
+}
+
 // MutateResponse For any view other than traces we convert FieldTypeNullableJSON to string
 func (h *QuestDB) MutateResponse(ctx context.Context, res data.Frames) (data.Frames, error) {
 	return res, nil
 }
+
+// assumeServiceAccountConnector wraps a driver.Connector so that every new physical
+// connection runs `ASSUME SERVICE ACCOUNT <sa>` exactly once before it is used. Because
+// sqlds keeps one pool per service account, the ASSUME runs per connection (not per
+// query) and never leaks between Grafana users; the account's memory limit then applies
+// to every query on the pool.
+type assumeServiceAccountConnector struct {
+	base driver.Connector
+	stmt string
+}
+
+func (c *assumeServiceAccountConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.base.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	execer, ok := conn.(driver.ExecerContext)
+	if !ok {
+		_ = conn.Close()
+		return nil, fmt.Errorf("connection does not support ExecContext; cannot ASSUME SERVICE ACCOUNT")
+	}
+	if _, err := execer.ExecContext(ctx, c.stmt, nil); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to assume service account: %w", err)
+	}
+	return conn, nil
+}
+
+func (c *assumeServiceAccountConnector) Driver() driver.Driver { return c.base.Driver() }
 
 // postgresProxyDialer implements the postgres dialer using a proxy dialer, as their functions differ slightly
 type postgresProxyDialer struct {

--- a/pkg/plugin/driver.go
+++ b/pkg/plugin/driver.go
@@ -326,7 +326,9 @@ func (h *QuestDB) MutateQueryData(ctx context.Context, req *backend.QueryDataReq
 // malformed (non-object) JSON it returns the input unchanged.
 func withConnectionArgs(queryJSON, connArgs json.RawMessage) json.RawMessage {
 	m := map[string]json.RawMessage{}
-	if err := json.Unmarshal(queryJSON, &m); err != nil {
+	// JSON `null` unmarshals into a nil map with no error; without the m == nil guard the
+	// m["connectionArgs"] assignment below would panic ("assignment to entry in nil map").
+	if err := json.Unmarshal(queryJSON, &m); err != nil || m == nil {
 		return queryJSON
 	}
 	if connArgs == nil {

--- a/pkg/plugin/routing_integration_test.go
+++ b/pkg/plugin/routing_integration_test.go
@@ -1,0 +1,134 @@
+package plugin_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/questdb/grafana-questdb-datasource/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServiceAccountRoutingIntegration verifies the end-to-end ASSUME SERVICE ACCOUNT
+// behavior (design §12) against a running QuestDB *Enterprise* instance. Service accounts
+// and memory limits are Enterprise-only, so the default OSS test container cannot run it;
+// the test is skipped unless QUESTDB_ENTERPRISE=true. To run it, point QUESTDB_HOST /
+// QUESTDB_PORT (and credentials) at an Enterprise instance whose login can create service
+// accounts and set memory limits, e.g.:
+//
+//	QUESTDB_USE_DOCKER=false QUESTDB_ENTERPRISE=true QUESTDB_HOST=... QUESTDB_PORT=... \
+//	  go test ./pkg/plugin/ -run TestServiceAccountRoutingIntegration -v
+//
+// NOTE: the memory-limit thresholds / heavy query below are best-effort and may need
+// tuning for the target instance's resources.
+func TestServiceAccountRoutingIntegration(t *testing.T) {
+	if strings.ToLower(getEnv("QUESTDB_ENTERPRISE", "false")) != "true" {
+		t.Skip("requires QuestDB Enterprise; set QUESTDB_ENTERPRISE=true and point QUESTDB_HOST/PORT at it")
+	}
+
+	admin := setupConnection(t)
+	defer admin.Close()
+
+	const sa = "sa_grafana_it"
+	username := getEnv("QUESTDB_USERNAME", "admin")
+
+	mustExec := func(q string) {
+		_, err := admin.Exec(q)
+		require.NoError(t, err, q)
+	}
+	_, _ = admin.Exec("DROP SERVICE ACCOUNT " + sa) // best-effort cleanup from a prior run
+	mustExec("CREATE SERVICE ACCOUNT " + sa)
+	_, _ = admin.Exec("GRANT SELECT ON ALL TABLES TO " + sa) // best-effort; not needed by long_sequence()
+	mustExec(fmt.Sprintf("GRANT ASSUME SERVICE ACCOUNT %s TO %s", sa, username))
+	t.Cleanup(func() { _, _ = admin.Exec("DROP SERVICE ACCOUNT " + sa) })
+
+	// A modestly memory-hungry query: a high-cardinality aggregation.
+	const heavy = "SELECT x, count() FROM long_sequence(1000000) GROUP BY x"
+
+	t.Run("assume runs and queries work through the routed pool", func(t *testing.T) {
+		routed := routedConnection(t, sa)
+		defer routed.Close()
+		require.NoError(t, routed.Ping())
+		var x int64
+		require.NoError(t, routed.QueryRow("SELECT x FROM long_sequence(1)").Scan(&x))
+		assert.Equal(t, int64(1), x)
+	})
+
+	t.Run("memory limit on the service account is enforced", func(t *testing.T) {
+		// Unlimited: the query succeeds through the routed (assumed) pool.
+		mustExec(fmt.Sprintf("ALTER SERVICE ACCOUNT %s SET MEMORY LIMIT 0", sa))
+		unlimited := routedConnection(t, sa)
+		_, err := unlimited.Exec(heavy)
+		require.NoError(t, err, "unlimited service account should run the query")
+		unlimited.Close()
+
+		// Tight limit: the same query on a fresh pool must hit the cap. Only the limit
+		// changed, so a failure here is attributable to the service account's limit.
+		mustExec(fmt.Sprintf("ALTER SERVICE ACCOUNT %s SET MEMORY LIMIT 1K", sa))
+		limited := routedConnection(t, sa)
+		defer limited.Close()
+		_, err = limited.Exec(heavy)
+		assert.Error(t, err, "tightly-capped service account should fail the query")
+	})
+
+	t.Run("EXIT SERVICE ACCOUNT reverts to the base login", func(t *testing.T) {
+		mustExec(fmt.Sprintf("ALTER SERVICE ACCOUNT %s SET MEMORY LIMIT 0", sa))
+		routed := routedConnection(t, sa)
+		defer routed.Close()
+		// Pin a single physical connection so EXIT and the follow-up run on the same session.
+		conn, err := routed.Conn(context.Background())
+		require.NoError(t, err)
+		defer conn.Close()
+		_, err = conn.ExecContext(context.Background(), "EXIT SERVICE ACCOUNT")
+		require.NoError(t, err)
+		var x int64
+		require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT x FROM long_sequence(1)").Scan(&x))
+		assert.Equal(t, int64(1), x)
+	})
+}
+
+// routedConnection opens a *sql.DB through the plugin's Connect with service-account
+// routing enabled, mirroring how sqlds would call it with a stamped connectionArgs
+// message. Every physical connection in the returned pool assumes sa.
+func routedConnection(t *testing.T, sa string) *sql.DB {
+	t.Helper()
+	host := getEnv("QUESTDB_HOST", "localhost")
+	port := getEnv("QUESTDB_PORT", "8812")
+	username := getEnv("QUESTDB_USERNAME", "admin")
+	password := getEnv("QUESTDB_PASSWORD", "quest")
+	tlsEnabled := getEnv("QUESTDB_TLS_ENABLED", "false")
+
+	secure := map[string]string{"password": password}
+	tlsMode := "disable"
+	tlsMethod := ""
+	if tlsEnabled == "true" {
+		tlsMode = "verify-full"
+		tlsMethod = "file-content"
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		caCert, err := os.ReadFile(path.Join(cwd, "../../keys/my-own-ca.crt"))
+		require.NoError(t, err)
+		secure["tlsCACert"] = string(caCert)
+	}
+
+	jsonData := fmt.Sprintf(
+		`{"server":%q,"port":%s,"username":%q,"tlsMode":%q,"tlsConfigurationMethod":%q,"serviceAccountRoutingEnabled":true}`,
+		host, port, username, tlsMode, tlsMethod)
+	cfg := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(jsonData),
+		DecryptedSecureJSONData: secure,
+	}
+	msg, err := json.Marshal(map[string]string{"serviceAccount": sa})
+	require.NoError(t, err)
+
+	db, err := (&plugin.QuestDB{}).Connect(context.Background(), cfg, msg)
+	require.NoError(t, err)
+	return db
+}

--- a/pkg/plugin/routing_integration_test.go
+++ b/pkg/plugin/routing_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/lib/pq"
 	"github.com/questdb/grafana-questdb-datasource/pkg/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,6 +79,31 @@ func TestServiceAccountRoutingIntegration(t *testing.T) {
 		assert.Error(t, err, "tightly-capped service account should fail the query")
 	})
 
+	t.Run("memory limit still applies after a prior error on the same pooled connection", func(t *testing.T) {
+		// Regression guard for the per-connection ASSUME model (review #2/#6): a query that
+		// errors — here a memory-limit abort — must NOT silently revert the physical
+		// connection to the base login. We pin ONE physical connection, fail a heavy query on
+		// it, then prove the SAME reused connection is still capped. If the assumed account
+		// had reverted to the (unlimited admin) base login, the second heavy query would
+		// instead succeed. Confirmed against the Enterprise PGWire source: the assumed account
+		// lives in the per-connection SecurityContext.accessList, survives the per-query reset
+		// and non-fatal query errors, and reverts only on explicit EXIT, grant revocation, or
+		// connection teardown.
+		mustExec(fmt.Sprintf("ALTER SERVICE ACCOUNT %s SET MEMORY LIMIT 1K", sa))
+		routed := routedConnection(t, sa)
+		defer routed.Close()
+
+		conn, err := routed.Conn(context.Background())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.ExecContext(context.Background(), heavy)
+		requireMemoryLimitError(t, err, "first heavy query on the pinned connection should hit the cap")
+
+		_, err = conn.ExecContext(context.Background(), heavy)
+		requireMemoryLimitError(t, err, "reused connection must still be capped after the prior error")
+	})
+
 	t.Run("EXIT SERVICE ACCOUNT reverts to the base login", func(t *testing.T) {
 		mustExec(fmt.Sprintf("ALTER SERVICE ACCOUNT %s SET MEMORY LIMIT 0", sa))
 		routed := routedConnection(t, sa)
@@ -131,4 +157,17 @@ func routedConnection(t *testing.T, sa string) *sql.DB {
 	db, err := (&plugin.QuestDB{}).Connect(context.Background(), cfg, msg)
 	require.NoError(t, err)
 	return db
+}
+
+// requireMemoryLimitError asserts that err is a server-side pq error rather than a
+// closed/dead-connection error. QuestDB surfaces a memory-limit abort as a normal PGWire
+// ErrorResponse (the connection stays open), which lib/pq returns as *pq.Error; asserting
+// that — instead of just "some error" — proves the physical connection stayed alive AND the
+// query was rejected by the cap, so a passing reuse case means the assumed service account
+// survived the prior error rather than the connection having silently died.
+func requireMemoryLimitError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	var pqErr *pq.Error
+	require.ErrorAs(t, err, &pqErr, msg+" (expected a server-side pq error, not a dropped connection)")
 }

--- a/pkg/plugin/routing_integration_test.go
+++ b/pkg/plugin/routing_integration_test.go
@@ -120,6 +120,90 @@ func TestServiceAccountRoutingIntegration(t *testing.T) {
 	})
 }
 
+// TestPostCheckHealthRoutingIntegration verifies review #1's fix end-to-end against a
+// running QuestDB *Enterprise* instance: Save & Test (PostCheckHealth) must actually run an
+// ASSUME for the default service account, so a routing misconfiguration fails here rather
+// than passing the green base-login check and breaking only on routed dashboard queries.
+// Enterprise-gated for the same reason as TestServiceAccountRoutingIntegration.
+func TestPostCheckHealthRoutingIntegration(t *testing.T) {
+	if strings.ToLower(getEnv("QUESTDB_ENTERPRISE", "false")) != "true" {
+		t.Skip("requires QuestDB Enterprise; set QUESTDB_ENTERPRISE=true and point QUESTDB_HOST/PORT at it")
+	}
+
+	admin := setupConnection(t)
+	defer admin.Close()
+
+	const sa = "sa_grafana_health_it"
+	username := getEnv("QUESTDB_USERNAME", "admin")
+
+	_, _ = admin.Exec("DROP SERVICE ACCOUNT " + sa) // best-effort cleanup from a prior run
+	_, err := admin.Exec("CREATE SERVICE ACCOUNT " + sa)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = admin.Exec("DROP SERVICE ACCOUNT " + sa) })
+
+	ctx := context.Background()
+	h := &plugin.QuestDB{}
+
+	// Review #1's exact failure scenario: the account exists but the data source login was
+	// never GRANTed ASSUME on it. The base Save & Test (default pool, no ASSUME) is green, so
+	// without PostCheckHealth this misconfiguration would surface only on routed queries.
+	t.Run("unhealthy when GRANT ASSUME is missing", func(t *testing.T) {
+		res := h.PostCheckHealth(ctx, healthCheckRequest(t, sa))
+		require.NotNil(t, res, "missing GRANT ASSUME must fail Save & Test")
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+	})
+
+	t.Run("healthy once the default account is granted and assumable", func(t *testing.T) {
+		_, err := admin.Exec(fmt.Sprintf("GRANT ASSUME SERVICE ACCOUNT %s TO %s", sa, username))
+		require.NoError(t, err)
+		res := h.PostCheckHealth(ctx, healthCheckRequest(t, sa))
+		assert.Nil(t, res, "a granted, assumable default account should pass Save & Test")
+	})
+
+	t.Run("unhealthy when the default account does not exist", func(t *testing.T) {
+		res := h.PostCheckHealth(ctx, healthCheckRequest(t, "sa_does_not_exist_xyz"))
+		require.NotNil(t, res, "a non-existent default account must fail Save & Test")
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+	})
+}
+
+// healthCheckRequest builds a CheckHealthRequest whose data source enables routing with the
+// given default service account, pointed at the test QuestDB instance (mirrors how Grafana
+// invokes CheckHealth with the decrypted password present).
+func healthCheckRequest(t *testing.T, defaultSA string) *backend.CheckHealthRequest {
+	t.Helper()
+	host := getEnv("QUESTDB_HOST", "localhost")
+	port := getEnv("QUESTDB_PORT", "8812")
+	username := getEnv("QUESTDB_USERNAME", "admin")
+	password := getEnv("QUESTDB_PASSWORD", "quest")
+	tlsEnabled := getEnv("QUESTDB_TLS_ENABLED", "false")
+
+	secure := map[string]string{"password": password}
+	tlsMode := "disable"
+	tlsMethod := ""
+	if tlsEnabled == "true" {
+		tlsMode = "verify-full"
+		tlsMethod = "file-content"
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		caCert, err := os.ReadFile(path.Join(cwd, "../../keys/my-own-ca.crt"))
+		require.NoError(t, err)
+		secure["tlsCACert"] = string(caCert)
+	}
+
+	jsonData := fmt.Sprintf(
+		`{"server":%q,"port":%s,"username":%q,"tlsMode":%q,"tlsConfigurationMethod":%q,"serviceAccountRoutingEnabled":true,"defaultServiceAccount":%q}`,
+		host, port, username, tlsMode, tlsMethod, defaultSA)
+	return &backend.CheckHealthRequest{
+		PluginContext: backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+				JSONData:                []byte(jsonData),
+				DecryptedSecureJSONData: secure,
+			},
+		},
+	}
+}
+
 // routedConnection opens a *sql.DB through the plugin's Connect with service-account
 // routing enabled, mirroring how sqlds would call it with a stamped connectionArgs
 // message. Every physical connection in the returned pool assumes sa.

--- a/pkg/plugin/routing_integration_test.go
+++ b/pkg/plugin/routing_integration_test.go
@@ -76,7 +76,7 @@ func TestServiceAccountRoutingIntegration(t *testing.T) {
 		limited := routedConnection(t, sa)
 		defer limited.Close()
 		_, err = limited.Exec(heavy)
-		assert.Error(t, err, "tightly-capped service account should fail the query")
+		requireMemoryLimitError(t, err, "tightly-capped service account should fail the query")
 	})
 
 	t.Run("memory limit still applies after a prior error on the same pooled connection", func(t *testing.T) {
@@ -231,15 +231,21 @@ func routedConnection(t *testing.T, sa string) *sql.DB {
 	return db
 }
 
-// requireMemoryLimitError asserts that err is a server-side pq error rather than a
-// closed/dead-connection error. QuestDB surfaces a memory-limit abort as a normal PGWire
-// ErrorResponse (the connection stays open), which lib/pq returns as *pq.Error; asserting
-// that — instead of just "some error" — proves the physical connection stayed alive AND the
-// query was rejected by the cap, so a passing reuse case means the assumed service account
-// survived the prior error rather than the connection having silently died.
+// requireMemoryLimitError asserts that err is QuestDB's memory-limit abort: a server-side
+// pq error (a normal PGWire ErrorResponse, so the connection stays open and lib/pq returns
+// *pq.Error) whose message is the memory-limit cap specifically. Requiring *pq.Error rather
+// than just "some error" proves the physical connection stayed alive — so a passing reuse
+// case means the assumed service account survived the prior error rather than the connection
+// having silently died — and matching the message proves the failure is the cap, not some
+// other server-side rejection. A service-account MEMORY LIMIT is enforced as a per-workload
+// tracker limit, so QuestDB Enterprise emits "query memory limit exceeded [workload=...]";
+// the server-wide cap emits "global RSS memory limit exceeded [...]". Both contain the
+// substring "memory limit exceeded" (see io.questdb.std.Unsafe in questdb-enterprise).
 func requireMemoryLimitError(t *testing.T, err error, msg string) {
 	t.Helper()
 	require.Error(t, err, msg)
 	var pqErr *pq.Error
 	require.ErrorAs(t, err, &pqErr, msg+" (expected a server-side pq error, not a dropped connection)")
+	assert.Contains(t, strings.ToLower(pqErr.Message), "memory limit exceeded",
+		msg+" (expected a QuestDB memory-limit abort, not another server-side error)")
 }

--- a/pkg/plugin/routing_integration_test.go
+++ b/pkg/plugin/routing_integration_test.go
@@ -167,10 +167,10 @@ func TestPostCheckHealthRoutingIntegration(t *testing.T) {
 	})
 }
 
-// healthCheckRequest builds a CheckHealthRequest whose data source enables routing with the
-// given default service account, pointed at the test QuestDB instance (mirrors how Grafana
-// invokes CheckHealth with the decrypted password present).
-func healthCheckRequest(t *testing.T, defaultSA string) *backend.CheckHealthRequest {
+// routingTestConfig builds the shared jsonData + decrypted-secure map pointing at the test
+// QuestDB instance with service-account routing enabled. extraJSON is appended verbatim as
+// additional jsonData fields (e.g. `,"defaultServiceAccount":"sa"`); pass "" for none.
+func routingTestConfig(t *testing.T, extraJSON string) ([]byte, map[string]string) {
 	t.Helper()
 	host := getEnv("QUESTDB_HOST", "localhost")
 	port := getEnv("QUESTDB_PORT", "8812")
@@ -192,12 +192,21 @@ func healthCheckRequest(t *testing.T, defaultSA string) *backend.CheckHealthRequ
 	}
 
 	jsonData := fmt.Sprintf(
-		`{"server":%q,"port":%s,"username":%q,"tlsMode":%q,"tlsConfigurationMethod":%q,"serviceAccountRoutingEnabled":true,"defaultServiceAccount":%q}`,
-		host, port, username, tlsMode, tlsMethod, defaultSA)
+		`{"server":%q,"port":%s,"username":%q,"tlsMode":%q,"tlsConfigurationMethod":%q,"serviceAccountRoutingEnabled":true%s}`,
+		host, port, username, tlsMode, tlsMethod, extraJSON)
+	return []byte(jsonData), secure
+}
+
+// healthCheckRequest builds a CheckHealthRequest whose data source enables routing with the
+// given default service account, pointed at the test QuestDB instance (mirrors how Grafana
+// invokes CheckHealth with the decrypted password present).
+func healthCheckRequest(t *testing.T, defaultSA string) *backend.CheckHealthRequest {
+	t.Helper()
+	jsonData, secure := routingTestConfig(t, fmt.Sprintf(`,"defaultServiceAccount":%q`, defaultSA))
 	return &backend.CheckHealthRequest{
 		PluginContext: backend.PluginContext{
 			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
-				JSONData:                []byte(jsonData),
+				JSONData:                jsonData,
 				DecryptedSecureJSONData: secure,
 			},
 		},
@@ -209,30 +218,9 @@ func healthCheckRequest(t *testing.T, defaultSA string) *backend.CheckHealthRequ
 // message. Every physical connection in the returned pool assumes sa.
 func routedConnection(t *testing.T, sa string) *sql.DB {
 	t.Helper()
-	host := getEnv("QUESTDB_HOST", "localhost")
-	port := getEnv("QUESTDB_PORT", "8812")
-	username := getEnv("QUESTDB_USERNAME", "admin")
-	password := getEnv("QUESTDB_PASSWORD", "quest")
-	tlsEnabled := getEnv("QUESTDB_TLS_ENABLED", "false")
-
-	secure := map[string]string{"password": password}
-	tlsMode := "disable"
-	tlsMethod := ""
-	if tlsEnabled == "true" {
-		tlsMode = "verify-full"
-		tlsMethod = "file-content"
-		cwd, err := os.Getwd()
-		require.NoError(t, err)
-		caCert, err := os.ReadFile(path.Join(cwd, "../../keys/my-own-ca.crt"))
-		require.NoError(t, err)
-		secure["tlsCACert"] = string(caCert)
-	}
-
-	jsonData := fmt.Sprintf(
-		`{"server":%q,"port":%s,"username":%q,"tlsMode":%q,"tlsConfigurationMethod":%q,"serviceAccountRoutingEnabled":true}`,
-		host, port, username, tlsMode, tlsMethod)
+	jsonData, secure := routingTestConfig(t, "")
 	cfg := backend.DataSourceInstanceSettings{
-		JSONData:                []byte(jsonData),
+		JSONData:                jsonData,
 		DecryptedSecureJSONData: secure,
 	}
 	msg, err := json.Marshal(map[string]string{"serviceAccount": sa})

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -271,6 +271,13 @@ func TestBuildAssumeStatement(t *testing.T) {
 			"sa_analysts": `ASSUME SERVICE ACCOUNT "sa_analysts"`,
 			"sa-execs":    `ASSUME SERVICE ACCOUNT "sa-execs"`,
 			"team.a_1":    `ASSUME SERVICE ACCOUNT "team.a_1"`,
+			// QuestDB allows these (mirrored denylist), so the plugin must too — see
+			// AccessListUtilsTest in questdb-enterprise. Notably a space, '@' and email form.
+			"john.doe@mail.com": `ASSUME SERVICE ACCOUNT "john.doe@mail.com"`,
+			"data team":         `ASSUME SERVICE ACCOUNT "data team"`,
+			"team!1":            `ASSUME SERVICE ACCOUNT "team!1"`,
+			"sa^x":              `ASSUME SERVICE ACCOUNT "sa^x"`,
+			"sa;ok":             `ASSUME SERVICE ACCOUNT "sa;ok"`,
 		}
 		for name, want := range valid {
 			got, err := buildAssumeStatement(name)
@@ -286,15 +293,28 @@ func TestBuildAssumeStatement(t *testing.T) {
 	})
 
 	t.Run("rejects injection / malformed names", func(t *testing.T) {
+		// Every entry contains a character QuestDB itself forbids in entity names
+		// (AccessListUtils.validateEntityName); '"' and '\\' in particular keep the quoted
+		// identifier injection-safe. A space or ';' is intentionally NOT here — QuestDB
+		// permits those, and the "valid names" case above asserts the plugin does too.
 		bad := []string{
-			`sa"; DROP TABLE x;--`,
-			`sa name`,
-			`sa;`,
-			`sa"a`,
-			`sa'a`,
-			"sa\na",
-			`"`,
-			`sa)`,
+			`sa"; DROP TABLE x;--`, // contains '"'
+			`sa"a`,                 // '"'
+			`sa\a`,                 // '\'
+			`sa'a`,                 // '\''
+			"sa\na",                // newline (control char)
+			"sa\ta",                // tab (control char)
+			`"`,                    // '"'
+			`sa)`,                  // ')'
+			`sa(x`,                 // '('
+			`sa/x`,                 // '/'
+			`sa:x`,                 // ':'
+			`sa,x`,                 // ','
+			`sa+x`,                 // '+'
+			`sa*x`,                 // '*'
+			`sa%x`,                 // '%'
+			`sa~x`,                 // '~'
+			`sa?x`,                 // '?'
 		}
 		for _, name := range bad {
 			_, err := buildAssumeStatement(name)
@@ -627,12 +647,15 @@ func TestConnectServiceAccountWrapping(t *testing.T) {
 	}
 
 	t.Run("invalid service account name errors at connect", func(t *testing.T) {
-		msg, err := json.Marshal(connectionArgs{ServiceAccount: "bad name!"})
+		// ')' is in QuestDB's forbidden set; a space or '@' would be accepted (see
+		// TestBuildAssumeStatement), so use a genuinely-forbidden character here.
+		msg, err := json.Marshal(connectionArgs{ServiceAccount: "bad)name"})
 		require.NoError(t, err)
 		db, err := (&QuestDB{}).Connect(context.Background(), cfg, msg)
 		require.Error(t, err)
 		assert.Nil(t, db)
-		assert.Contains(t, err.Error(), "invalid service account name")
+		assert.Contains(t, err.Error(), "invalid character")
+		assert.Contains(t, err.Error(), "bad)name")
 	})
 
 	t.Run("valid service account name wires the pool without error", func(t *testing.T) {
@@ -642,5 +665,107 @@ func TestConnectServiceAccountWrapping(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, db)
 		_ = db.Close()
+	})
+}
+
+// TestValidateServiceAccountNames verifies review #2's fix: configured service-account names
+// are checked at config time (so Save & Test catches a typo) rather than only at query time.
+func TestValidateServiceAccountNames(t *testing.T) {
+	t.Run("all valid names pass", func(t *testing.T) {
+		// Includes names QuestDB allows but the old allowlist rejected (space, '@', email
+		// form), locking in the "match QuestDB's denylist" decision.
+		s := Settings{
+			DefaultServiceAccount:       "sa_default",
+			ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "john.doe@mail.com"}},
+			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "data team"}},
+		}
+		assert.NoError(t, s.validateServiceAccountNames())
+	})
+
+	t.Run("blank names are skipped, not rejected", func(t *testing.T) {
+		// A blank default/mapping/group target means "fall through", which is valid config.
+		s := Settings{
+			DefaultServiceAccount:       "   ",
+			ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: ""}},
+			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "  "}},
+		}
+		assert.NoError(t, s.validateServiceAccountNames())
+	})
+
+	t.Run("invalid default account is rejected and named", func(t *testing.T) {
+		// ')' is in QuestDB's forbidden set (a space would now be accepted); the full
+		// forbidden charset is covered by TestBuildAssumeStatement.
+		s := Settings{DefaultServiceAccount: "sa)oops"}
+		err := s.validateServiceAccountNames()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sa)oops")
+	})
+
+	t.Run("invalid user-mapping account is rejected and named", func(t *testing.T) {
+		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "bad/name"}}}
+		err := s.validateServiceAccountNames()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad/name")
+	})
+
+	t.Run("invalid group-mapping account is rejected and named", func(t *testing.T) {
+		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "sa(evil"}}}
+		err := s.validateServiceAccountNames()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "sa(evil")
+	})
+}
+
+// TestPostCheckHealth verifies review #1's fix: the health check exercises the routing path.
+// The branches here need no live DB — routing-disabled and name-validation short-circuit
+// before any connection, and the unreachable-server case proves the probe actually dials.
+func TestPostCheckHealth(t *testing.T) {
+	h := &QuestDB{}
+	ctx := context.Background()
+
+	healthReq := func(dsi *backend.DataSourceInstanceSettings) *backend.CheckHealthRequest {
+		return &backend.CheckHealthRequest{PluginContext: backend.PluginContext{DataSourceInstanceSettings: dsi}}
+	}
+
+	t.Run("nil datasource settings is healthy", func(t *testing.T) {
+		assert.Nil(t, h.PostCheckHealth(ctx, healthReq(nil)))
+	})
+
+	t.Run("routing disabled is healthy", func(t *testing.T) {
+		assert.Nil(t, h.PostCheckHealth(ctx, healthReq(mutateDSI(""))))
+	})
+
+	t.Run("invalid configured name fails before any DB probe", func(t *testing.T) {
+		// mutateDSI carries no password/secure data, so if validation did NOT short-circuit,
+		// the probe's Connect would fail for an unrelated (missing-credentials) reason. A
+		// message that names the bad account proves the failure is the config-time name check.
+		// ')' is in QuestDB's forbidden set (a space would be accepted and reach the probe).
+		dsi := mutateDSI(`"serviceAccountRoutingEnabled": true, "defaultServiceAccount": "bad)name"`)
+		res := h.PostCheckHealth(ctx, healthReq(dsi))
+		require.NotNil(t, res)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "bad)name")
+	})
+
+	t.Run("valid names with no default account is healthy (nothing to probe)", func(t *testing.T) {
+		dsi := mutateDSI(`"serviceAccountRoutingEnabled": true,
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_analysts" }]`)
+		assert.Nil(t, h.PostCheckHealth(ctx, healthReq(dsi)))
+	})
+
+	t.Run("valid default account probes the server and surfaces a connection failure", func(t *testing.T) {
+		// Routing on with a valid default name, so PostCheckHealth opens a routed pool and
+		// pings it. The server is unreachable (loopback port 1 → connection refused), so the
+		// probe — and thus Save & Test — fails. This proves the ASSUME path is actually
+		// dialed at health-check time, which is the gap review #1 reported.
+		dsi := &backend.DataSourceInstanceSettings{
+			JSONData: []byte(`{"server":"127.0.0.1","port":1,"username":"u","tlsMode":"disable",` +
+				`"timeout":"1","serviceAccountRoutingEnabled":true,"defaultServiceAccount":"sa_default"}`),
+			DecryptedSecureJSONData: map[string]string{"password": "p"},
+		}
+		res := h.PostCheckHealth(ctx, healthReq(dsi))
+		require.NotNil(t, res)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "sa_default")
 	})
 }

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -90,6 +90,14 @@ func TestLoadServiceAccountSettings(t *testing.T) {
 	})
 }
 
+// resolveServiceAccount is a test-only convenience wrapper: the eager form of
+// resolveServiceAccountLazy that takes already-resolved groups. Production code calls
+// resolveServiceAccountLazy directly so a forwarded OIDC token is decoded only when the
+// group step is actually reached; the tests don't need that laziness.
+func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
+	return settings.resolveServiceAccountLazy(user, func() []string { return groups })
+}
+
 func TestResolveServiceAccount(t *testing.T) {
 	settings := Settings{
 		DefaultServiceAccount: "sa_default",

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -99,13 +99,13 @@ func (settings *Settings) resolveServiceAccount(user *backend.User, groups []str
 }
 
 func TestResolveServiceAccount(t *testing.T) {
-	settings := Settings{
+	settings := Settings{serviceAccountConfig: serviceAccountConfig{
 		DefaultServiceAccount: "sa_default",
 		ServiceAccountMappings: []ServiceAccountMapping{
 			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
 			{GrafanaUser: "ceo", ServiceAccount: "sa_execs"},
 		},
-	}
+	}}
 
 	tests := []struct {
 		name string
@@ -126,16 +126,16 @@ func TestResolveServiceAccount(t *testing.T) {
 	}
 
 	t.Run("empty default and no match returns empty", func(t *testing.T) {
-		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}}}
 		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
 		assert.Equal(t, "", s.resolveServiceAccount(nil, nil))
 	})
 
 	t.Run("blank mapping service account falls through to the default", func(t *testing.T) {
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:  "sa_default",
 			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "   "}},
-		}
+		}}
 		// Without a default, a blank mapping must not assume the base login implicitly.
 		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 		s.DefaultServiceAccount = ""
@@ -143,44 +143,44 @@ func TestResolveServiceAccount(t *testing.T) {
 	})
 
 	t.Run("a later non-blank row for the same user still matches", func(t *testing.T) {
-		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountMappings: []ServiceAccountMapping{
 			{GrafanaUser: "john", ServiceAccount: ""},
 			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
-		}}
+		}}}
 		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 	})
 
 	t.Run("whitespace is trimmed from resolved names", func(t *testing.T) {
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:  "  sa_default  ",
 			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "  sa_analysts  "}},
-		}
+		}}
 		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
 	})
 
 	t.Run("whitespace-only default resolves to empty", func(t *testing.T) {
-		s := Settings{DefaultServiceAccount: "   "}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{DefaultServiceAccount: "   "}}
 		assert.Equal(t, "", s.resolveServiceAccount(nil, nil))
 		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
 	})
 
 	t.Run("whitespace around the mapping username still matches", func(t *testing.T) {
-		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "  john  ", ServiceAccount: "sa_analysts"}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "  john  ", ServiceAccount: "sa_analysts"}}}}
 		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "  john  "}, nil))
 	})
 }
 
 func TestResolveServiceAccountGroups(t *testing.T) {
-	settings := Settings{
+	settings := Settings{serviceAccountConfig: serviceAccountConfig{
 		DefaultServiceAccount:  "sa_default",
 		ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
 		ServiceAccountGroupMappings: []ServiceAccountGroupMapping{
 			{Group: "Analysts", ServiceAccount: "sa_analysts"},
 			{Group: "Execs", ServiceAccount: "sa_execs"},
 		},
-	}
+	}}
 
 	t.Run("group match when the user is unmapped", func(t *testing.T) {
 		assert.Equal(t, "sa_analysts", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Analysts"}))
@@ -215,20 +215,20 @@ func TestResolveServiceAccountGroups(t *testing.T) {
 	})
 
 	t.Run("blank group service account is skipped", func(t *testing.T) {
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:       "sa_default",
 			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Analysts", ServiceAccount: "  "}},
-		}
+		}}
 		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Analysts"}))
 	})
 
 	t.Run("blank group name matches nothing", func(t *testing.T) {
-		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  ", ServiceAccount: "sa_blank"}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  ", ServiceAccount: "sa_blank"}}}}
 		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"", "Analysts"}))
 	})
 
 	t.Run("group names and resolved SA are trimmed on both sides", func(t *testing.T) {
-		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  Analysts  ", ServiceAccount: "  sa_analysts  "}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  Analysts  ", ServiceAccount: "  sa_analysts  "}}}}
 		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"  Analysts  "}))
 	})
 }
@@ -237,11 +237,11 @@ func TestResolveServiceAccountGroups(t *testing.T) {
 // resolution actually reaches the group step, so a forwarded OIDC token is not decoded for
 // users a username mapping already covers (nor when no group mappings are configured).
 func TestResolveServiceAccountLazy(t *testing.T) {
-	withMappings := Settings{
+	withMappings := Settings{serviceAccountConfig: serviceAccountConfig{
 		DefaultServiceAccount:       "sa_default",
 		ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
 		ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Analysts", ServiceAccount: "sa_grp"}},
-	}
+	}}
 
 	t.Run("groups func not called when a username mapping matches", func(t *testing.T) {
 		called := false
@@ -254,10 +254,10 @@ func TestResolveServiceAccountLazy(t *testing.T) {
 	})
 
 	t.Run("groups func not called when no group mappings are configured", func(t *testing.T) {
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:  "sa_default",
 			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
-		}
+		}}
 		called := false
 		sa := s.resolveServiceAccountLazy(&backend.User{Login: "nobody"}, func() []string {
 			called = true
@@ -763,42 +763,42 @@ func TestValidateServiceAccountNames(t *testing.T) {
 	t.Run("all valid names pass", func(t *testing.T) {
 		// Includes names QuestDB allows but the old allowlist rejected (space, '@', email
 		// form), locking in the "match QuestDB's denylist" decision.
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:       "sa_default",
 			ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "john.doe@mail.com"}},
 			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "data team"}},
-		}
+		}}
 		assert.NoError(t, s.validateServiceAccountNames())
 	})
 
 	t.Run("blank names are skipped, not rejected", func(t *testing.T) {
 		// A blank default/mapping/group target means "fall through", which is valid config.
-		s := Settings{
+		s := Settings{serviceAccountConfig: serviceAccountConfig{
 			DefaultServiceAccount:       "   ",
 			ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: ""}},
 			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "  "}},
-		}
+		}}
 		assert.NoError(t, s.validateServiceAccountNames())
 	})
 
 	t.Run("invalid default account is rejected and named", func(t *testing.T) {
 		// ')' is in QuestDB's forbidden set (a space would now be accepted); the full
 		// forbidden charset is covered by TestBuildAssumeStatement.
-		s := Settings{DefaultServiceAccount: "sa)oops"}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{DefaultServiceAccount: "sa)oops"}}
 		err := s.validateServiceAccountNames()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "sa)oops")
 	})
 
 	t.Run("invalid user-mapping account is rejected and named", func(t *testing.T) {
-		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "bad/name"}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "bad/name"}}}}
 		err := s.validateServiceAccountNames()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bad/name")
 	})
 
 	t.Run("invalid group-mapping account is rejected and named", func(t *testing.T) {
-		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "sa(evil"}}}
+		s := Settings{serviceAccountConfig: serviceAccountConfig{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Execs", ServiceAccount: "sa(evil"}}}}
 		err := s.validateServiceAccountNames()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "sa(evil")

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -137,6 +137,12 @@ func TestResolveServiceAccount(t *testing.T) {
 		assert.Equal(t, "", s.resolveServiceAccount(nil, nil))
 		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
 	})
+
+	t.Run("whitespace around the mapping username still matches", func(t *testing.T) {
+		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "  john  ", ServiceAccount: "sa_analysts"}}}
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "  john  "}, nil))
+	})
 }
 
 func TestResolveServiceAccountGroups(t *testing.T) {
@@ -529,6 +535,39 @@ func TestMutateQueryData(t *testing.T) {
 		_, out := h.MutateQueryData(ctx, req)
 		assert.JSONEq(t, `{"serviceAccount":"sa_default"}`, string(stamped(t, out)))
 	})
+
+	t.Run("client-supplied connectionArgs is overwritten for a mapped user", func(t *testing.T) {
+		// A query payload that smuggles its own service account must not survive: the
+		// resolved account replaces it so the client cannot pick its own memory limit.
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(routingEnabled), User: &backend.User{Login: "john"}},
+			Queries: []backend.DataQuery{
+				{RefID: "A", JSON: []byte(`{"rawSql":"select 1","connectionArgs":{"serviceAccount":"sa_evil"}}`)},
+			},
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"serviceAccount":"sa_analysts"}`, string(stamped(t, out)))
+	})
+
+	t.Run("client-supplied connectionArgs is stripped when the user resolves to no account", func(t *testing.T) {
+		// Unmapped user, no default: the base login is used, but the client's smuggled
+		// connectionArgs must be removed rather than honored (otherwise it would select
+		// an arbitrary account the base login can assume).
+		noDefault := `"serviceAccountRoutingEnabled": true,
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_analysts" }]`
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(noDefault), User: &backend.User{Login: "nobody"}},
+			Queries: []backend.DataQuery{
+				{RefID: "A", JSON: []byte(`{"rawSql":"select 1","connectionArgs":{"serviceAccount":"sa_evil"}}`)},
+			},
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(out.Queries[0].JSON, &m))
+		_, ok := m["connectionArgs"]
+		assert.False(t, ok, "client-supplied connectionArgs must be stripped, not honored")
+		assert.JSONEq(t, `"select 1"`, string(m["rawSql"]))
+	})
 }
 
 func TestWithConnectionArgs(t *testing.T) {
@@ -561,6 +600,20 @@ func TestWithConnectionArgs(t *testing.T) {
 		// A JSON array cannot be unmarshalled into map[string]json.RawMessage.
 		in := json.RawMessage(`["a","b"]`)
 		assert.Equal(t, string(in), string(withConnectionArgs(in, connArgs)))
+	})
+
+	t.Run("nil connArgs removes an existing connectionArgs", func(t *testing.T) {
+		in := json.RawMessage(`{"rawSql":"select 1","connectionArgs":{"serviceAccount":"sa_evil"}}`)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(withConnectionArgs(in, nil), &m))
+		_, ok := m["connectionArgs"]
+		assert.False(t, ok)
+		assert.JSONEq(t, `"select 1"`, string(m["rawSql"]))
+	})
+
+	t.Run("nil connArgs leaves bytes untouched when no connectionArgs present", func(t *testing.T) {
+		in := json.RawMessage(`{"rawSql":"select 1","format":1}`)
+		assert.Equal(t, string(in), string(withConnectionArgs(in, nil)))
 	})
 }
 

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -641,6 +641,14 @@ func TestWithConnectionArgs(t *testing.T) {
 		assert.Equal(t, string(in), string(withConnectionArgs(in, connArgs)))
 	})
 
+	t.Run("returns input unchanged on JSON null without panicking", func(t *testing.T) {
+		// `null` is the one non-object input that unmarshals without error (into a nil map);
+		// the stamp path (non-nil connArgs) must not panic on the map assignment.
+		in := json.RawMessage(`null`)
+		assert.Equal(t, string(in), string(withConnectionArgs(in, connArgs)))
+		assert.Equal(t, string(in), string(withConnectionArgs(in, nil)))
+	})
+
 	t.Run("nil connArgs removes an existing connectionArgs", func(t *testing.T) {
 		in := json.RawMessage(`{"rawSql":"select 1","connectionArgs":{"serviceAccount":"sa_evil"}}`)
 		var m map[string]json.RawMessage

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -225,6 +225,55 @@ func TestResolveServiceAccountGroups(t *testing.T) {
 	})
 }
 
+// TestResolveServiceAccountLazy locks in that the groups callback is consulted only when
+// resolution actually reaches the group step, so a forwarded OIDC token is not decoded for
+// users a username mapping already covers (nor when no group mappings are configured).
+func TestResolveServiceAccountLazy(t *testing.T) {
+	withMappings := Settings{
+		DefaultServiceAccount:       "sa_default",
+		ServiceAccountMappings:      []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
+		ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Analysts", ServiceAccount: "sa_grp"}},
+	}
+
+	t.Run("groups func not called when a username mapping matches", func(t *testing.T) {
+		called := false
+		sa := withMappings.resolveServiceAccountLazy(&backend.User{Login: "john"}, func() []string {
+			called = true
+			return []string{"Analysts"}
+		})
+		assert.Equal(t, "sa_user", sa)
+		assert.False(t, called, "groups func must not run once a username mapping has won")
+	})
+
+	t.Run("groups func not called when no group mappings are configured", func(t *testing.T) {
+		s := Settings{
+			DefaultServiceAccount:  "sa_default",
+			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
+		}
+		called := false
+		sa := s.resolveServiceAccountLazy(&backend.User{Login: "nobody"}, func() []string {
+			called = true
+			return []string{"Analysts"}
+		})
+		assert.Equal(t, "sa_default", sa)
+		assert.False(t, called, "groups func must not run when there are no group mappings to match")
+	})
+
+	t.Run("groups func called and used when username misses and group mappings exist", func(t *testing.T) {
+		called := false
+		sa := withMappings.resolveServiceAccountLazy(&backend.User{Login: "nobody"}, func() []string {
+			called = true
+			return []string{"Analysts"}
+		})
+		assert.Equal(t, "sa_grp", sa)
+		assert.True(t, called, "groups func must run to reach a group mapping")
+	})
+
+	t.Run("nil groups func is tolerated and falls through to the default", func(t *testing.T) {
+		assert.Equal(t, "sa_default", withMappings.resolveServiceAccountLazy(&backend.User{Login: "nobody"}, nil))
+	})
+}
+
 // makeIDToken hand-crafts a JWT (header.payload.signature) carrying the given claims. The
 // signature segment is a placeholder — extractGroups does not verify it (design D11/D12).
 func makeIDToken(t *testing.T, claims map[string]interface{}) string {
@@ -273,10 +322,15 @@ func TestExtractGroups(t *testing.T) {
 		assert.Nil(t, extractGroups(token, "groups"))
 	})
 
-	t.Run("claim that is not a string array returns nil", func(t *testing.T) {
-		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": "single"}), "groups"))
+	t.Run("claim that is neither a string nor a string array returns nil", func(t *testing.T) {
 		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": []int{1, 2}}), "groups"))
 		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": map[string]interface{}{"a": 1}}), "groups"))
+		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": 123}), "groups"))
+	})
+
+	t.Run("single string claim is treated as a one-element group list", func(t *testing.T) {
+		// Some IdPs serialize a single group as a scalar string rather than a 1-element array.
+		assert.Equal(t, []string{"Analysts"}, extractGroups(makeIDToken(t, map[string]interface{}{"groups": "Analysts"}), "groups"))
 	})
 
 	t.Run("empty groups array returns an empty (non-nil) slice", func(t *testing.T) {

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -69,6 +69,25 @@ func TestLoadServiceAccountSettings(t *testing.T) {
 		assert.Equal(t, "sa_default", s.DefaultServiceAccount)
 		assert.Equal(t, []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}, s.ServiceAccountMappings)
 	})
+
+	t.Run("type mismatch returns an error but still parses what it can", func(t *testing.T) {
+		// Hand-provisioned YAML can produce a type mismatch the frontend never would (here a
+		// numeric serviceAccount). json.Unmarshal records the error yet keeps populating: the
+		// per-query path runs with this partial parse (the bad row's account is blanked, so
+		// resolveServiceAccount skips it rather than dropping the user onto the uncapped base
+		// login unguarded), while PostCheckHealth surfaces the error at Save & Test.
+		var s Settings
+		err := applyServiceAccountSettings(&s, []byte(`{
+			"serviceAccountRoutingEnabled": true,
+			"defaultServiceAccount": "sa_default",
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": 123 }]
+		}`))
+		require.Error(t, err)
+		assert.True(t, s.ServiceAccountRoutingEnabled)
+		assert.Equal(t, "sa_default", s.DefaultServiceAccount)
+		require.Len(t, s.ServiceAccountMappings, 1)
+		assert.Equal(t, "", s.ServiceAccountMappings[0].ServiceAccount)
+	})
 }
 
 func TestResolveServiceAccount(t *testing.T) {
@@ -733,6 +752,29 @@ func TestPostCheckHealth(t *testing.T) {
 
 	t.Run("routing disabled is healthy", func(t *testing.T) {
 		assert.Nil(t, h.PostCheckHealth(ctx, healthReq(mutateDSI(""))))
+	})
+
+	t.Run("malformed routing block fails before any DB probe", func(t *testing.T) {
+		// A provisioned type mismatch (numeric serviceAccount) unmarshals partially and would
+		// otherwise drop the row, routing the user to the uncapped base login unnoticed. The
+		// DSI carries no credentials, so reaching the probe would fail for an unrelated reason;
+		// a parse-specific message proves we short-circuit at config time.
+		dsi := mutateDSI(`"serviceAccountRoutingEnabled": true,
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": 123 }]`)
+		res := h.PostCheckHealth(ctx, healthReq(dsi))
+		require.NotNil(t, res)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "could not parse routing configuration")
+	})
+
+	t.Run("mistyped enable flag is caught even though it parses as disabled", func(t *testing.T) {
+		// The enable flag itself is the type-mismatched field, so it falls back to false; an
+		// enabled-first check would skip silently. The parse-error check runs first to catch it.
+		dsi := mutateDSI(`"serviceAccountRoutingEnabled": "yes"`)
+		res := h.PostCheckHealth(ctx, healthReq(dsi))
+		require.NotNil(t, res)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "could not parse routing configuration")
 	})
 
 	t.Run("invalid configured name fails before any DB probe", func(t *testing.T) {

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -1,0 +1,400 @@
+package plugin
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadServiceAccountSettings(t *testing.T) {
+	t.Run("parses routing fields", func(t *testing.T) {
+		cfg := backend.DataSourceInstanceSettings{
+			JSONData: []byte(`{ "server": "h", "port": 8812, "username": "u",
+				"serviceAccountRoutingEnabled": true, "defaultServiceAccount": "sa_default",
+				"serviceAccountMappings": [
+					{ "grafanaUser": "john", "serviceAccount": "sa_analysts" },
+					{ "grafanaUser": "jane", "serviceAccount": "sa_analysts" }
+				] }`),
+			DecryptedSecureJSONData: map[string]string{"password": "p"},
+		}
+		s, err := LoadSettings(cfg)
+		require.NoError(t, err)
+		assert.True(t, s.ServiceAccountRoutingEnabled)
+		assert.Equal(t, "sa_default", s.DefaultServiceAccount)
+		assert.Equal(t, []ServiceAccountMapping{
+			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
+			{GrafanaUser: "jane", ServiceAccount: "sa_analysts"},
+		}, s.ServiceAccountMappings)
+	})
+
+	t.Run("defaults to disabled when fields absent", func(t *testing.T) {
+		cfg := backend.DataSourceInstanceSettings{
+			JSONData:                []byte(`{ "server": "h", "port": 8812, "username": "u" }`),
+			DecryptedSecureJSONData: map[string]string{"password": "p"},
+		}
+		s, err := LoadSettings(cfg)
+		require.NoError(t, err)
+		assert.False(t, s.ServiceAccountRoutingEnabled)
+		assert.Equal(t, "", s.DefaultServiceAccount)
+		assert.Nil(t, s.ServiceAccountMappings)
+	})
+
+	t.Run("LoadServiceAccountSettings parses without requiring credentials", func(t *testing.T) {
+		// No server/port/username/password — routing config must still parse.
+		cfg := backend.DataSourceInstanceSettings{
+			JSONData: []byte(`{ "serviceAccountRoutingEnabled": true, "defaultServiceAccount": "sa_default",
+				"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_analysts" }] }`),
+		}
+		s := LoadServiceAccountSettings(cfg)
+		assert.True(t, s.ServiceAccountRoutingEnabled)
+		assert.Equal(t, "sa_default", s.DefaultServiceAccount)
+		assert.Equal(t, []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}, s.ServiceAccountMappings)
+	})
+}
+
+func TestResolveServiceAccount(t *testing.T) {
+	settings := Settings{
+		DefaultServiceAccount: "sa_default",
+		ServiceAccountMappings: []ServiceAccountMapping{
+			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
+			{GrafanaUser: "ceo", ServiceAccount: "sa_execs"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		user *backend.User
+		want string
+	}{
+		{name: "mapped user", user: &backend.User{Login: "john"}, want: "sa_analysts"},
+		{name: "case-insensitive match", user: &backend.User{Login: "JoHn"}, want: "sa_analysts"},
+		{name: "another mapped user", user: &backend.User{Login: "ceo"}, want: "sa_execs"},
+		{name: "unmapped user falls back to default", user: &backend.User{Login: "nobody"}, want: "sa_default"},
+		{name: "nil user falls back to default", user: nil, want: "sa_default"},
+		{name: "empty login falls back to default", user: &backend.User{Login: ""}, want: "sa_default"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, settings.resolveServiceAccount(tt.user))
+		})
+	}
+
+	t.Run("empty default and no match returns empty", func(t *testing.T) {
+		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}}
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
+		assert.Equal(t, "", s.resolveServiceAccount(nil))
+	})
+
+	t.Run("blank mapping service account falls through to the default", func(t *testing.T) {
+		s := Settings{
+			DefaultServiceAccount:  "sa_default",
+			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "   "}},
+		}
+		// Without a default, a blank mapping must not assume the base login implicitly.
+		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "john"}))
+		s.DefaultServiceAccount = ""
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "john"}))
+	})
+
+	t.Run("a later non-blank row for the same user still matches", func(t *testing.T) {
+		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{
+			{GrafanaUser: "john", ServiceAccount: ""},
+			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
+		}}
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}))
+	})
+
+	t.Run("whitespace is trimmed from resolved names", func(t *testing.T) {
+		s := Settings{
+			DefaultServiceAccount:  "  sa_default  ",
+			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "  sa_analysts  "}},
+		}
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}))
+		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
+	})
+
+	t.Run("whitespace-only default resolves to empty", func(t *testing.T) {
+		s := Settings{DefaultServiceAccount: "   "}
+		assert.Equal(t, "", s.resolveServiceAccount(nil))
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
+	})
+}
+
+func TestBuildAssumeStatement(t *testing.T) {
+	t.Run("valid names", func(t *testing.T) {
+		valid := map[string]string{
+			"sa_analysts": `ASSUME SERVICE ACCOUNT "sa_analysts"`,
+			"sa-execs":    `ASSUME SERVICE ACCOUNT "sa-execs"`,
+			"team.a_1":    `ASSUME SERVICE ACCOUNT "team.a_1"`,
+		}
+		for name, want := range valid {
+			got, err := buildAssumeStatement(name)
+			require.NoError(t, err, name)
+			assert.Equal(t, want, got)
+		}
+	})
+
+	t.Run("empty name is a no-op", func(t *testing.T) {
+		got, err := buildAssumeStatement("")
+		require.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("rejects injection / malformed names", func(t *testing.T) {
+		bad := []string{
+			`sa"; DROP TABLE x;--`,
+			`sa name`,
+			`sa;`,
+			`sa"a`,
+			`sa'a`,
+			"sa\na",
+			`"`,
+			`sa)`,
+		}
+		for _, name := range bad {
+			_, err := buildAssumeStatement(name)
+			assert.Error(t, err, name)
+		}
+	})
+}
+
+// --- fakes for the connector wrapper ---
+
+type fakeConnector struct {
+	conn       driver.Conn
+	connectErr error
+}
+
+func (c *fakeConnector) Connect(_ context.Context) (driver.Conn, error) {
+	if c.connectErr != nil {
+		return nil, c.connectErr
+	}
+	return c.conn, nil
+}
+func (c *fakeConnector) Driver() driver.Driver { return nil }
+
+// execerConn implements driver.Conn and driver.ExecerContext, recording the statement.
+type execerConn struct {
+	lastQuery string
+	closed    bool
+	execErr   error
+}
+
+func (c *execerConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (c *execerConn) Close() error                        { c.closed = true; return nil }
+func (c *execerConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+func (c *execerConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.lastQuery = query
+	if c.execErr != nil {
+		return nil, c.execErr
+	}
+	return driver.RowsAffected(0), nil
+}
+
+// plainConn implements only driver.Conn (no ExecerContext).
+type plainConn struct{ closed bool }
+
+func (c *plainConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (c *plainConn) Close() error                        { c.closed = true; return nil }
+func (c *plainConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+
+func TestAssumeServiceAccountConnector(t *testing.T) {
+	const stmt = `ASSUME SERVICE ACCOUNT "sa_a"`
+
+	t.Run("runs ASSUME once and returns the conn", func(t *testing.T) {
+		fc := &execerConn{}
+		asc := &assumeServiceAccountConnector{base: &fakeConnector{conn: fc}, stmt: stmt}
+		got, err := asc.Connect(context.Background())
+		require.NoError(t, err)
+		assert.Same(t, fc, got)
+		assert.Equal(t, stmt, fc.lastQuery)
+		assert.False(t, fc.closed)
+	})
+
+	t.Run("closes conn and propagates exec error", func(t *testing.T) {
+		fc := &execerConn{execErr: errors.New("boom")}
+		asc := &assumeServiceAccountConnector{base: &fakeConnector{conn: fc}, stmt: stmt}
+		_, err := asc.Connect(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to assume service account")
+		assert.True(t, fc.closed)
+	})
+
+	t.Run("errors when conn lacks ExecContext", func(t *testing.T) {
+		pc := &plainConn{}
+		asc := &assumeServiceAccountConnector{base: &fakeConnector{conn: pc}, stmt: stmt}
+		_, err := asc.Connect(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not support ExecContext")
+		assert.True(t, pc.closed)
+	})
+
+	t.Run("propagates base connect error", func(t *testing.T) {
+		asc := &assumeServiceAccountConnector{base: &fakeConnector{connectErr: errors.New("dial fail")}, stmt: stmt}
+		_, err := asc.Connect(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dial fail")
+	})
+}
+
+func mutateDSI(extraJSON string) *backend.DataSourceInstanceSettings {
+	jsonData := `{ "server": "h", "port": 8812, "username": "u", "tlsMode": "disable"`
+	if extraJSON != "" {
+		jsonData += ", " + extraJSON
+	}
+	jsonData += " }"
+	// Deliberately no DecryptedSecureJSONData: routing resolution must not require credentials.
+	return &backend.DataSourceInstanceSettings{
+		JSONData: []byte(jsonData),
+	}
+}
+
+func makeQueries() []backend.DataQuery {
+	return []backend.DataQuery{
+		{RefID: "A", JSON: []byte(`{"rawSql":"select 1","format":1}`)},
+		{RefID: "B", JSON: []byte(`{"rawSql":"select 2","format":0}`)},
+	}
+}
+
+func TestMutateQueryData(t *testing.T) {
+	h := &QuestDB{}
+	ctx := context.Background()
+
+	routingEnabled := `"serviceAccountRoutingEnabled": true, "defaultServiceAccount": "sa_default",
+		"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_analysts" }]`
+
+	t.Run("nil datasource settings is a no-op", func(t *testing.T) {
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{User: &backend.User{Login: "john"}},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"rawSql":"select 1","format":1}`, string(out.Queries[0].JSON))
+	})
+
+	t.Run("routing disabled leaves queries unchanged", func(t *testing.T) {
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(""), User: &backend.User{Login: "john"}},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"rawSql":"select 1","format":1}`, string(out.Queries[0].JSON))
+		assert.JSONEq(t, `{"rawSql":"select 2","format":0}`, string(out.Queries[1].JSON))
+	})
+
+	t.Run("mapped user stamps connectionArgs, preserving fields", func(t *testing.T) {
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(routingEnabled), User: &backend.User{Login: "john"}},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		for i, raw := range []string{`"select 1"`, `"select 2"`} {
+			var m map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(out.Queries[i].JSON, &m))
+			assert.JSONEq(t, `{"serviceAccount":"sa_analysts"}`, string(m["connectionArgs"]))
+			assert.JSONEq(t, raw, string(m["rawSql"]))
+		}
+	})
+
+	t.Run("nil user resolves to default service account", func(t *testing.T) {
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(routingEnabled), User: nil},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(out.Queries[0].JSON, &m))
+		assert.JSONEq(t, `{"serviceAccount":"sa_default"}`, string(m["connectionArgs"]))
+	})
+
+	t.Run("unmapped user with no default leaves queries unchanged", func(t *testing.T) {
+		noDefault := `"serviceAccountRoutingEnabled": true,
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_analysts" }]`
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(noDefault), User: &backend.User{Login: "nobody"}},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"rawSql":"select 1","format":1}`, string(out.Queries[0].JSON))
+	})
+
+	t.Run("blank mapping falls through to the default service account", func(t *testing.T) {
+		blank := `"serviceAccountRoutingEnabled": true, "defaultServiceAccount": "sa_default",
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "" }]`
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(blank), User: &backend.User{Login: "john"}},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(out.Queries[0].JSON, &m))
+		assert.JSONEq(t, `{"serviceAccount":"sa_default"}`, string(m["connectionArgs"]))
+	})
+}
+
+func TestWithConnectionArgs(t *testing.T) {
+	connArgs := json.RawMessage(`{"serviceAccount":"sa_a"}`)
+
+	t.Run("adds connectionArgs preserving all other fields", func(t *testing.T) {
+		in := json.RawMessage(`{"rawSql":"select 1","format":1,"selectedFormat":2,"meta":{"timezone":"UTC"}}`)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(withConnectionArgs(in, connArgs), &m))
+		assert.JSONEq(t, `{"serviceAccount":"sa_a"}`, string(m["connectionArgs"]))
+		assert.JSONEq(t, `"select 1"`, string(m["rawSql"]))
+		assert.JSONEq(t, `1`, string(m["format"]))
+		assert.JSONEq(t, `2`, string(m["selectedFormat"]))
+		assert.JSONEq(t, `{"timezone":"UTC"}`, string(m["meta"]))
+	})
+
+	t.Run("overwrites an existing connectionArgs", func(t *testing.T) {
+		in := json.RawMessage(`{"rawSql":"select 1","connectionArgs":{"serviceAccount":"old"}}`)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(withConnectionArgs(in, connArgs), &m))
+		assert.JSONEq(t, `{"serviceAccount":"sa_a"}`, string(m["connectionArgs"]))
+	})
+
+	t.Run("returns input unchanged on malformed JSON", func(t *testing.T) {
+		in := json.RawMessage(`not json`)
+		assert.Equal(t, string(in), string(withConnectionArgs(in, connArgs)))
+	})
+
+	t.Run("returns input unchanged on non-object JSON", func(t *testing.T) {
+		// A JSON array cannot be unmarshalled into map[string]json.RawMessage.
+		in := json.RawMessage(`["a","b"]`)
+		assert.Equal(t, string(in), string(withConnectionArgs(in, connArgs)))
+	})
+}
+
+func TestConnectServiceAccountWrapping(t *testing.T) {
+	// These exercise the routing branch of Connect without a live database: an invalid
+	// name errors before sql.OpenDB, and OpenDB itself is lazy (no connection until used).
+	baseJSON := `{"server":"h","port":8812,"username":"u","tlsMode":"disable","serviceAccountRoutingEnabled":true}`
+	cfg := backend.DataSourceInstanceSettings{
+		JSONData:                []byte(baseJSON),
+		DecryptedSecureJSONData: map[string]string{"password": "p"},
+	}
+
+	t.Run("invalid service account name errors at connect", func(t *testing.T) {
+		msg, err := json.Marshal(connectionArgs{ServiceAccount: "bad name!"})
+		require.NoError(t, err)
+		db, err := (&QuestDB{}).Connect(context.Background(), cfg, msg)
+		require.Error(t, err)
+		assert.Nil(t, db)
+		assert.Contains(t, err.Error(), "invalid service account name")
+	})
+
+	t.Run("valid service account name wires the pool without error", func(t *testing.T) {
+		msg, err := json.Marshal(connectionArgs{ServiceAccount: "sa_analysts"})
+		require.NoError(t, err)
+		db, err := (&QuestDB{}).Connect(context.Background(), cfg, msg)
+		require.NoError(t, err)
+		require.NotNil(t, db)
+		_ = db.Close()
+	})
+}

--- a/pkg/plugin/routing_test.go
+++ b/pkg/plugin/routing_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"database/sql/driver"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -20,6 +21,11 @@ func TestLoadServiceAccountSettings(t *testing.T) {
 				"serviceAccountMappings": [
 					{ "grafanaUser": "john", "serviceAccount": "sa_analysts" },
 					{ "grafanaUser": "jane", "serviceAccount": "sa_analysts" }
+				],
+				"groupsClaim": "roles",
+				"serviceAccountGroupMappings": [
+					{ "group": "Analysts", "serviceAccount": "sa_analysts" },
+					{ "group": "Execs", "serviceAccount": "sa_execs" }
 				] }`),
 			DecryptedSecureJSONData: map[string]string{"password": "p"},
 		}
@@ -31,6 +37,11 @@ func TestLoadServiceAccountSettings(t *testing.T) {
 			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
 			{GrafanaUser: "jane", ServiceAccount: "sa_analysts"},
 		}, s.ServiceAccountMappings)
+		assert.Equal(t, "roles", s.GroupsClaim)
+		assert.Equal(t, []ServiceAccountGroupMapping{
+			{Group: "Analysts", ServiceAccount: "sa_analysts"},
+			{Group: "Execs", ServiceAccount: "sa_execs"},
+		}, s.ServiceAccountGroupMappings)
 	})
 
 	t.Run("defaults to disabled when fields absent", func(t *testing.T) {
@@ -43,6 +54,8 @@ func TestLoadServiceAccountSettings(t *testing.T) {
 		assert.False(t, s.ServiceAccountRoutingEnabled)
 		assert.Equal(t, "", s.DefaultServiceAccount)
 		assert.Nil(t, s.ServiceAccountMappings)
+		assert.Nil(t, s.ServiceAccountGroupMappings)
+		assert.Equal(t, "", s.GroupsClaim)
 	})
 
 	t.Run("LoadServiceAccountSettings parses without requiring credentials", func(t *testing.T) {
@@ -81,14 +94,14 @@ func TestResolveServiceAccount(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, settings.resolveServiceAccount(tt.user))
+			assert.Equal(t, tt.want, settings.resolveServiceAccount(tt.user, nil))
 		})
 	}
 
 	t.Run("empty default and no match returns empty", func(t *testing.T) {
 		s := Settings{ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_analysts"}}}
-		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
-		assert.Equal(t, "", s.resolveServiceAccount(nil))
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
+		assert.Equal(t, "", s.resolveServiceAccount(nil, nil))
 	})
 
 	t.Run("blank mapping service account falls through to the default", func(t *testing.T) {
@@ -97,9 +110,9 @@ func TestResolveServiceAccount(t *testing.T) {
 			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "   "}},
 		}
 		// Without a default, a blank mapping must not assume the base login implicitly.
-		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "john"}))
+		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 		s.DefaultServiceAccount = ""
-		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "john"}))
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 	})
 
 	t.Run("a later non-blank row for the same user still matches", func(t *testing.T) {
@@ -107,7 +120,7 @@ func TestResolveServiceAccount(t *testing.T) {
 			{GrafanaUser: "john", ServiceAccount: ""},
 			{GrafanaUser: "john", ServiceAccount: "sa_analysts"},
 		}}
-		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}))
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
 	})
 
 	t.Run("whitespace is trimmed from resolved names", func(t *testing.T) {
@@ -115,14 +128,134 @@ func TestResolveServiceAccount(t *testing.T) {
 			DefaultServiceAccount:  "  sa_default  ",
 			ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "  sa_analysts  "}},
 		}
-		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}))
-		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "john"}, nil))
+		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
 	})
 
 	t.Run("whitespace-only default resolves to empty", func(t *testing.T) {
 		s := Settings{DefaultServiceAccount: "   "}
-		assert.Equal(t, "", s.resolveServiceAccount(nil))
-		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}))
+		assert.Equal(t, "", s.resolveServiceAccount(nil, nil))
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
+	})
+}
+
+func TestResolveServiceAccountGroups(t *testing.T) {
+	settings := Settings{
+		DefaultServiceAccount:  "sa_default",
+		ServiceAccountMappings: []ServiceAccountMapping{{GrafanaUser: "john", ServiceAccount: "sa_user"}},
+		ServiceAccountGroupMappings: []ServiceAccountGroupMapping{
+			{Group: "Analysts", ServiceAccount: "sa_analysts"},
+			{Group: "Execs", ServiceAccount: "sa_execs"},
+		},
+	}
+
+	t.Run("group match when the user is unmapped", func(t *testing.T) {
+		assert.Equal(t, "sa_analysts", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Analysts"}))
+	})
+
+	t.Run("group match is case-insensitive", func(t *testing.T) {
+		assert.Equal(t, "sa_execs", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"execs"}))
+	})
+
+	t.Run("username mapping beats group mapping", func(t *testing.T) {
+		// john has a username mapping; even though his token also carries a mapped group,
+		// the more specific username mapping wins.
+		assert.Equal(t, "sa_user", settings.resolveServiceAccount(&backend.User{Login: "john"}, []string{"Analysts"}))
+	})
+
+	t.Run("first configured group wins for multi-group membership", func(t *testing.T) {
+		// Member of both Execs and Analysts: Analysts is configured first, so it wins.
+		assert.Equal(t, "sa_analysts", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Execs", "Analysts"}))
+	})
+
+	t.Run("no matching group falls back to default", func(t *testing.T) {
+		assert.Equal(t, "sa_default", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Other"}))
+	})
+
+	t.Run("nil and empty groups fall back to default", func(t *testing.T) {
+		assert.Equal(t, "sa_default", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, nil))
+		assert.Equal(t, "sa_default", settings.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{}))
+	})
+
+	t.Run("nil user (alerting) with no groups falls back to default", func(t *testing.T) {
+		assert.Equal(t, "sa_default", settings.resolveServiceAccount(nil, nil))
+	})
+
+	t.Run("blank group service account is skipped", func(t *testing.T) {
+		s := Settings{
+			DefaultServiceAccount:       "sa_default",
+			ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "Analysts", ServiceAccount: "  "}},
+		}
+		assert.Equal(t, "sa_default", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"Analysts"}))
+	})
+
+	t.Run("blank group name matches nothing", func(t *testing.T) {
+		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  ", ServiceAccount: "sa_blank"}}}
+		assert.Equal(t, "", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"", "Analysts"}))
+	})
+
+	t.Run("group names and resolved SA are trimmed on both sides", func(t *testing.T) {
+		s := Settings{ServiceAccountGroupMappings: []ServiceAccountGroupMapping{{Group: "  Analysts  ", ServiceAccount: "  sa_analysts  "}}}
+		assert.Equal(t, "sa_analysts", s.resolveServiceAccount(&backend.User{Login: "nobody"}, []string{"  Analysts  "}))
+	})
+}
+
+// makeIDToken hand-crafts a JWT (header.payload.signature) carrying the given claims. The
+// signature segment is a placeholder — extractGroups does not verify it (design D11/D12).
+func makeIDToken(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	enc := base64.RawURLEncoding
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	return enc.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`)) + "." + enc.EncodeToString(payload) + ".sig"
+}
+
+func TestExtractGroups(t *testing.T) {
+	t.Run("reads the default groups claim", func(t *testing.T) {
+		token := makeIDToken(t, map[string]interface{}{"groups": []string{"Analysts", "Execs"}})
+		assert.Equal(t, []string{"Analysts", "Execs"}, extractGroups(token, ""))
+		assert.Equal(t, []string{"Analysts", "Execs"}, extractGroups(token, "groups"))
+	})
+
+	t.Run("reads a custom claim name", func(t *testing.T) {
+		token := makeIDToken(t, map[string]interface{}{"roles": []string{"Admins"}})
+		assert.Equal(t, []string{"Admins"}, extractGroups(token, "roles"))
+		assert.Nil(t, extractGroups(token, "groups")) // default claim absent in this token
+	})
+
+	t.Run("missing claim returns nil", func(t *testing.T) {
+		token := makeIDToken(t, map[string]interface{}{"sub": "u1"})
+		assert.Nil(t, extractGroups(token, "groups"))
+	})
+
+	t.Run("empty header returns nil", func(t *testing.T) {
+		assert.Nil(t, extractGroups("", "groups"))
+	})
+
+	t.Run("non-JWT strings return nil", func(t *testing.T) {
+		for _, s := range []string{"not-a-jwt", "a.b", "a.b.c.d", "header..sig"} {
+			assert.Nil(t, extractGroups(s, "groups"), s)
+		}
+	})
+
+	t.Run("non-base64url payload returns nil", func(t *testing.T) {
+		assert.Nil(t, extractGroups("aGVhZGVy.!!!not-base64!!!.sig", "groups"))
+	})
+
+	t.Run("payload that is not JSON returns nil", func(t *testing.T) {
+		enc := base64.RawURLEncoding
+		token := enc.EncodeToString([]byte("hdr")) + "." + enc.EncodeToString([]byte("not json")) + ".sig"
+		assert.Nil(t, extractGroups(token, "groups"))
+	})
+
+	t.Run("claim that is not a string array returns nil", func(t *testing.T) {
+		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": "single"}), "groups"))
+		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": []int{1, 2}}), "groups"))
+		assert.Nil(t, extractGroups(makeIDToken(t, map[string]interface{}{"groups": map[string]interface{}{"a": 1}}), "groups"))
+	})
+
+	t.Run("empty groups array returns an empty (non-nil) slice", func(t *testing.T) {
+		assert.Equal(t, []string{}, extractGroups(makeIDToken(t, map[string]interface{}{"groups": []string{}}), "groups"))
 	})
 }
 
@@ -335,6 +468,66 @@ func TestMutateQueryData(t *testing.T) {
 		var m map[string]json.RawMessage
 		require.NoError(t, json.Unmarshal(out.Queries[0].JSON, &m))
 		assert.JSONEq(t, `{"serviceAccount":"sa_default"}`, string(m["connectionArgs"]))
+	})
+
+	groupRouting := `"serviceAccountRoutingEnabled": true, "defaultServiceAccount": "sa_default",
+		"serviceAccountGroupMappings": [
+			{ "group": "Analysts", "serviceAccount": "sa_analysts" },
+			{ "group": "Execs", "serviceAccount": "sa_execs" }
+		]`
+
+	stamped := func(t *testing.T, out *backend.QueryDataRequest) json.RawMessage {
+		t.Helper()
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(out.Queries[0].JSON, &m))
+		return m["connectionArgs"]
+	}
+
+	t.Run("group from X-Id-Token stamps the group's service account", func(t *testing.T) {
+		token := makeIDToken(t, map[string]interface{}{"groups": []string{"Analysts"}})
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(groupRouting), User: &backend.User{Login: "nobody"}},
+			Headers:       map[string]string{"X-Id-Token": token},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"serviceAccount":"sa_analysts"}`, string(stamped(t, out)))
+	})
+
+	t.Run("username mapping overrides the token group", func(t *testing.T) {
+		both := `"serviceAccountRoutingEnabled": true,
+			"serviceAccountMappings": [{ "grafanaUser": "john", "serviceAccount": "sa_user" }],
+			"serviceAccountGroupMappings": [{ "group": "Analysts", "serviceAccount": "sa_analysts" }]`
+		token := makeIDToken(t, map[string]interface{}{"groups": []string{"Analysts"}})
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(both), User: &backend.User{Login: "john"}},
+			Headers:       map[string]string{"X-Id-Token": token},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"serviceAccount":"sa_user"}`, string(stamped(t, out)))
+	})
+
+	t.Run("custom groups claim is honored", func(t *testing.T) {
+		custom := `"serviceAccountRoutingEnabled": true, "groupsClaim": "roles",
+			"serviceAccountGroupMappings": [{ "group": "Execs", "serviceAccount": "sa_execs" }]`
+		token := makeIDToken(t, map[string]interface{}{"roles": []string{"Execs"}})
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(custom), User: &backend.User{Login: "nobody"}},
+			Headers:       map[string]string{"X-Id-Token": token},
+			Queries:       makeQueries(),
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"serviceAccount":"sa_execs"}`, string(stamped(t, out)))
+	})
+
+	t.Run("no token with group mappings falls back to the default", func(t *testing.T) {
+		req := &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: mutateDSI(groupRouting), User: &backend.User{Login: "nobody"}},
+			Queries:       makeQueries(), // no X-Id-Token header
+		}
+		_, out := h.MutateQueryData(ctx, req)
+		assert.JSONEq(t, `{"serviceAccount":"sa_default"}`, string(stamped(t, out)))
 	})
 }
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -33,11 +34,23 @@ type Settings struct {
 
 	TlsClientCertFile string `json:"tlsClientCertFile"`
 	TlsClientKeyFile  string `json:"tlsClientKeyFile"`
+
+	// Per-user service-account routing (optional; QuestDB Enterprise only).
+	ServiceAccountRoutingEnabled bool                    `json:"serviceAccountRoutingEnabled,omitempty"`
+	DefaultServiceAccount        string                  `json:"defaultServiceAccount,omitempty"`
+	ServiceAccountMappings       []ServiceAccountMapping `json:"serviceAccountMappings,omitempty"`
 }
 
 type CustomSetting struct {
 	Setting string `json:"setting"`
 	Value   string `json:"value"`
+}
+
+// ServiceAccountMapping maps a Grafana user login to a QuestDB service account.
+// Several users may point at the same service account to form a "group".
+type ServiceAccountMapping struct {
+	GrafanaUser    string `json:"grafanaUser"`
+	ServiceAccount string `json:"serviceAccount"`
 }
 
 func (settings *Settings) isValid() (err error) {
@@ -178,5 +191,77 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		}
 	}
 
+	// Service-account routing fields are simple native JSON types (bool/string/array),
+	// so a typed unmarshal is cleaner than the map extraction used above.
+	applyServiceAccountSettings(&settings, config.JSONData)
+
 	return settings, settings.isValid()
+}
+
+// applyServiceAccountSettings parses the (non-secret) service-account routing fields from
+// jsonData onto settings. jsonData is assumed to be valid JSON; a parse error simply
+// leaves the routing fields at their zero values (routing disabled).
+func applyServiceAccountSettings(settings *Settings, jsonData []byte) {
+	var sa struct {
+		ServiceAccountRoutingEnabled bool                    `json:"serviceAccountRoutingEnabled"`
+		DefaultServiceAccount        string                  `json:"defaultServiceAccount"`
+		ServiceAccountMappings       []ServiceAccountMapping `json:"serviceAccountMappings"`
+	}
+	_ = json.Unmarshal(jsonData, &sa)
+	settings.ServiceAccountRoutingEnabled = sa.ServiceAccountRoutingEnabled
+	settings.DefaultServiceAccount = sa.DefaultServiceAccount
+	settings.ServiceAccountMappings = sa.ServiceAccountMappings
+}
+
+// LoadServiceAccountSettings parses only the service-account routing fields. Unlike
+// LoadSettings it does not require valid credentials, so it is safe to call on the query
+// path (MutateQueryData): routing config is non-secret jsonData and is resolved before a
+// connection is established, independent of whether secrets are present in the request.
+func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Settings {
+	var settings Settings
+	applyServiceAccountSettings(&settings, config.JSONData)
+	return settings
+}
+
+// resolveServiceAccount maps the requesting Grafana user to a QuestDB service account.
+// It returns "" when no ASSUME should run (the query then runs as the base login):
+// either there is no match and no configured default, or routing is effectively a no-op.
+// A nil user (backend-initiated requests such as alerting/reporting) resolves to the
+// default service account.
+//
+// Mappings with a blank service account are skipped: a half-filled config row must not
+// silently make a mapped user bypass the cap by dropping to the base login — such a user
+// falls through to the default instead. Returned names are whitespace-trimmed.
+func (settings *Settings) resolveServiceAccount(user *backend.User) string {
+	if user != nil && user.Login != "" {
+		for _, m := range settings.ServiceAccountMappings {
+			if strings.TrimSpace(m.ServiceAccount) == "" {
+				continue
+			}
+			if strings.EqualFold(m.GrafanaUser, user.Login) {
+				return strings.TrimSpace(m.ServiceAccount)
+			}
+		}
+	}
+	return strings.TrimSpace(settings.DefaultServiceAccount) // "" when unset/blank
+}
+
+// serviceAccountNamePattern guards against SQL injection / malformed names from config.
+// It forbids whitespace, quotes and ';', so the name can be safely embedded in the
+// ASSUME statement below.
+var serviceAccountNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.\-]+$`)
+
+// buildAssumeStatement returns the statement run on each new connection for the given
+// service account. It returns ("", nil) when sa is empty, and an error when the name
+// fails validation. There is no trailing ';' — it is executed as a single statement
+// via ExecContext.
+func buildAssumeStatement(sa string) (string, error) {
+	if sa == "" {
+		return "", nil
+	}
+	if !serviceAccountNamePattern.MatchString(sa) {
+		return "", fmt.Errorf("invalid service account name %q", sa)
+	}
+	// The pattern forbids embedded double quotes, so the quoted identifier is injection-safe.
+	return `ASSUME SERVICE ACCOUNT "` + sa + `"`, nil
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -36,9 +36,12 @@ type Settings struct {
 	TlsClientKeyFile  string `json:"tlsClientKeyFile"`
 
 	// Per-user service-account routing (optional; QuestDB Enterprise only).
-	ServiceAccountRoutingEnabled bool                    `json:"serviceAccountRoutingEnabled,omitempty"`
-	DefaultServiceAccount        string                  `json:"defaultServiceAccount,omitempty"`
-	ServiceAccountMappings       []ServiceAccountMapping `json:"serviceAccountMappings,omitempty"`
+	ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled,omitempty"`
+	DefaultServiceAccount        string                       `json:"defaultServiceAccount,omitempty"`
+	ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings,omitempty"`
+	ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings,omitempty"`
+	// GroupsClaim is the ID-token claim that holds the user's groups; defaults to "groups".
+	GroupsClaim string `json:"groupsClaim,omitempty"`
 }
 
 type CustomSetting struct {
@@ -50,6 +53,14 @@ type CustomSetting struct {
 // Several users may point at the same service account to form a "group".
 type ServiceAccountMapping struct {
 	GrafanaUser    string `json:"grafanaUser"`
+	ServiceAccount string `json:"serviceAccount"`
+}
+
+// ServiceAccountGroupMapping maps an OAuth/OIDC group (e.g. an Okta group carried in the
+// forwarded ID token's groups claim) to a QuestDB service account. Several groups may
+// point at the same service account.
+type ServiceAccountGroupMapping struct {
+	Group          string `json:"group"`
 	ServiceAccount string `json:"serviceAccount"`
 }
 
@@ -203,14 +214,18 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 // leaves the routing fields at their zero values (routing disabled).
 func applyServiceAccountSettings(settings *Settings, jsonData []byte) {
 	var sa struct {
-		ServiceAccountRoutingEnabled bool                    `json:"serviceAccountRoutingEnabled"`
-		DefaultServiceAccount        string                  `json:"defaultServiceAccount"`
-		ServiceAccountMappings       []ServiceAccountMapping `json:"serviceAccountMappings"`
+		ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
+		DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
+		ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings"`
+		ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
+		GroupsClaim                  string                       `json:"groupsClaim"`
 	}
 	_ = json.Unmarshal(jsonData, &sa)
 	settings.ServiceAccountRoutingEnabled = sa.ServiceAccountRoutingEnabled
 	settings.DefaultServiceAccount = sa.DefaultServiceAccount
 	settings.ServiceAccountMappings = sa.ServiceAccountMappings
+	settings.ServiceAccountGroupMappings = sa.ServiceAccountGroupMappings
+	settings.GroupsClaim = sa.GroupsClaim
 }
 
 // LoadServiceAccountSettings parses only the service-account routing fields. Unlike
@@ -223,16 +238,22 @@ func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Setti
 	return settings
 }
 
-// resolveServiceAccount maps the requesting Grafana user to a QuestDB service account.
-// It returns "" when no ASSUME should run (the query then runs as the base login):
-// either there is no match and no configured default, or routing is effectively a no-op.
-// A nil user (backend-initiated requests such as alerting/reporting) resolves to the
-// default service account.
+// resolveServiceAccount maps the requesting Grafana user (and their OIDC groups, when
+// available) to a QuestDB service account. Precedence is most-specific-first:
+//
+//  1. username mapping  — exact (case-insensitive) match on user.Login
+//  2. group mapping     — first configured mapping whose group is in groups (case-insensitive)
+//  3. default service account
+//
+// It returns "" when none of the above yields a name (the query then runs as the base
+// login). A nil user (backend-initiated requests such as alerting/reporting) and an empty
+// groups slice both simply skip steps 1–2 and fall through to the default.
 //
 // Mappings with a blank service account are skipped: a half-filled config row must not
 // silently make a mapped user bypass the cap by dropping to the base login — such a user
-// falls through to the default instead. Returned names are whitespace-trimmed.
-func (settings *Settings) resolveServiceAccount(user *backend.User) string {
+// falls through to the next step instead. Returned names are whitespace-trimmed.
+func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
+	// 1. Username mapping (most specific).
 	if user != nil && user.Login != "" {
 		for _, m := range settings.ServiceAccountMappings {
 			if strings.TrimSpace(m.ServiceAccount) == "" {
@@ -243,7 +264,32 @@ func (settings *Settings) resolveServiceAccount(user *backend.User) string {
 			}
 		}
 	}
+	// 2. Group mapping. The plugin cannot see QuestDB-side limits to pick "most
+	// restrictive", so for a user in several mapped groups the first matching row in
+	// config order wins — a deterministic, operator-controlled tie-break.
+	if len(groups) > 0 {
+		for _, gm := range settings.ServiceAccountGroupMappings {
+			if strings.TrimSpace(gm.Group) == "" || strings.TrimSpace(gm.ServiceAccount) == "" {
+				continue
+			}
+			if containsFold(groups, strings.TrimSpace(gm.Group)) {
+				return strings.TrimSpace(gm.ServiceAccount)
+			}
+		}
+	}
+	// 3. Default.
 	return strings.TrimSpace(settings.DefaultServiceAccount) // "" when unset/blank
+}
+
+// containsFold reports whether needle equals any element of haystack, case-insensitively
+// and ignoring surrounding whitespace on both sides.
+func containsFold(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if strings.EqualFold(strings.TrimSpace(s), needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // serviceAccountNamePattern guards against SQL injection / malformed names from config.

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -202,16 +202,23 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 	}
 
 	// Service-account routing fields are simple native JSON types (bool/string/array),
-	// so a typed unmarshal is cleaner than the map extraction used above.
-	applyServiceAccountSettings(&settings, config.JSONData)
+	// so a typed unmarshal is cleaner than the map extraction used above. A parse error is
+	// ignored here (this path also backs the per-query DriverSettings lookup); PostCheckHealth
+	// surfaces a malformed routing block at Save & Test instead.
+	_ = applyServiceAccountSettings(&settings, config.JSONData)
 
 	return settings, settings.isValid()
 }
 
 // applyServiceAccountSettings parses the (non-secret) service-account routing fields from
-// jsonData onto settings. jsonData is assumed to be valid JSON; a parse error simply
-// leaves the routing fields at their zero values (routing disabled).
-func applyServiceAccountSettings(settings *Settings, jsonData []byte) {
+// jsonData onto settings and returns the json.Unmarshal error, if any. The per-query path
+// ignores that error: a partial parse degrades safely (an unparseable mapping row drops its
+// account and the affected user falls through toward the base login). Config-time callers
+// (PostCheckHealth) surface it instead, so a provisioned type mismatch — e.g. a numeric
+// serviceAccount, or a quoted boolean for the enable flag — fails Save & Test rather than
+// silently mis-routing. A whole-document syntax error cannot occur via LoadSettings (it has
+// already parsed the same bytes); the realistic error is exactly such a field type mismatch.
+func applyServiceAccountSettings(settings *Settings, jsonData []byte) error {
 	var sa struct {
 		ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
 		DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
@@ -219,12 +226,13 @@ func applyServiceAccountSettings(settings *Settings, jsonData []byte) {
 		ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
 		GroupsClaim                  string                       `json:"groupsClaim"`
 	}
-	_ = json.Unmarshal(jsonData, &sa)
+	err := json.Unmarshal(jsonData, &sa)
 	settings.ServiceAccountRoutingEnabled = sa.ServiceAccountRoutingEnabled
 	settings.DefaultServiceAccount = sa.DefaultServiceAccount
 	settings.ServiceAccountMappings = sa.ServiceAccountMappings
 	settings.ServiceAccountGroupMappings = sa.ServiceAccountGroupMappings
 	settings.GroupsClaim = sa.GroupsClaim
+	return err
 }
 
 // LoadServiceAccountSettings parses only the service-account routing fields. Unlike
@@ -233,7 +241,7 @@ func applyServiceAccountSettings(settings *Settings, jsonData []byte) {
 // connection is established, independent of whether secrets are present in the request.
 func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Settings {
 	var settings Settings
-	applyServiceAccountSettings(&settings, config.JSONData)
+	_ = applyServiceAccountSettings(&settings, config.JSONData)
 	return settings
 }
 

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -299,10 +298,58 @@ func containsFold(haystack []string, needle string) bool {
 	return false
 }
 
-// serviceAccountNamePattern guards against SQL injection / malformed names from config.
-// It forbids whitespace, quotes and ';', so the name can be safely embedded in the
-// ASSUME statement below.
-var serviceAccountNamePattern = regexp.MustCompile(`^[A-Za-z0-9_.\-]+$`)
+// forbiddenServiceAccountNameChars mirrors the punctuation that QuestDB Enterprise rejects
+// in entity names (server-side AccessListUtils.validateEntityName). We deliberately mirror
+// QuestDB's denylist rather than impose a stricter allowlist, so the plugin accepts exactly
+// the names QuestDB itself accepts (e.g. email-style `john.doe@mail.com`, or names with
+// spaces). Crucially the set includes '"' and '\\', so the name remains injection-safe when
+// embedded as the quoted identifier in `ASSUME SERVICE ACCOUNT "<sa>"` below.
+const forbiddenServiceAccountNameChars = `?,'"\/:)(+*%~`
+
+// validateServiceAccountName reports whether sa is a valid QuestDB service-account name,
+// mirroring QuestDB's server-side rule: reject a fixed set of punctuation plus control
+// characters (C0 0x00–0x0F, DEL, and the UTF-8 BOM — matching QuestDB exactly). The caller
+// trims surrounding whitespace and treats "" as a no-op, so sa is expected non-empty here.
+// QuestDB's configurable max name length is intentionally NOT enforced client-side (the
+// server's value is unknown to the plugin); an over-long name is caught by the live ASSUME
+// health probe instead.
+func validateServiceAccountName(sa string) error {
+	if sa == "" {
+		return fmt.Errorf("service account name cannot be empty")
+	}
+	for _, r := range sa {
+		if r <= 0x0f || r == 0x7f || r == 0xfeff || strings.ContainsRune(forbiddenServiceAccountNameChars, r) {
+			return fmt.Errorf("invalid character %q in service account name %q", r, sa)
+		}
+	}
+	return nil
+}
+
+// validateServiceAccountNames checks every configured service-account name (the default
+// plus all user- and group-mapping targets) so a typo or unsupported character is reported
+// at Save & Test time instead of silently failing every routed query later. Blank names
+// are skipped: by design a blank default/mapping means "fall through to the next step",
+// not an error. It returns the first offending name's error.
+func (settings *Settings) validateServiceAccountNames() error {
+	names := make([]string, 0, 1+len(settings.ServiceAccountMappings)+len(settings.ServiceAccountGroupMappings))
+	names = append(names, settings.DefaultServiceAccount)
+	for _, m := range settings.ServiceAccountMappings {
+		names = append(names, m.ServiceAccount)
+	}
+	for _, gm := range settings.ServiceAccountGroupMappings {
+		names = append(names, gm.ServiceAccount)
+	}
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if err := validateServiceAccountName(n); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // buildAssumeStatement returns the statement run on each new connection for the given
 // service account. It returns ("", nil) when sa is empty, and an error when the name
@@ -312,9 +359,10 @@ func buildAssumeStatement(sa string) (string, error) {
 	if sa == "" {
 		return "", nil
 	}
-	if !serviceAccountNamePattern.MatchString(sa) {
-		return "", fmt.Errorf("invalid service account name %q", sa)
+	if err := validateServiceAccountName(sa); err != nil {
+		return "", err
 	}
-	// The pattern forbids embedded double quotes, so the quoted identifier is injection-safe.
+	// validateServiceAccountName forbids embedded double quotes and backslashes, so the
+	// double-quoted identifier cannot be broken out of — the statement is injection-safe.
 	return `ASSUME SERVICE ACCOUNT "` + sa + `"`, nil
 }

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -79,161 +79,136 @@ func (settings *Settings) isValid() (err error) {
 	return nil
 }
 
+// int64OrString is an integer setting that tolerates being provisioned either as a JSON
+// number (8812) or as a quoted string ("8812"); Grafana's frontend and provisioning have
+// historically stored these numeric settings both ways, so a single json.Unmarshal of the
+// config needs a type that accepts both forms. An absent field or a JSON null leaves it zero.
+type int64OrString int64
+
+func (n *int64OrString) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		return nil
+	}
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		// Base 0 matches the previous strconv.ParseInt(..., 0, 64) behavior.
+		v, err := strconv.ParseInt(s, 0, 64)
+		if err != nil {
+			return err
+		}
+		*n = int64OrString(v)
+		return nil
+	}
+	// A JSON number; truncate a fractional form, as the old float64->int64 path did.
+	var f float64
+	if err := json.Unmarshal(b, &f); err != nil {
+		return err
+	}
+	*n = int64OrString(f)
+	return nil
+}
+
+// jsonDataSettings is the wire shape of the non-secret jsonData blob. LoadSettings unmarshals
+// the config into it once — numeric fields via int64OrString so a string-encoded number still
+// parses — and copies it into Settings; secrets come separately from DecryptedSecureJSONData.
+// The routing fields are the shared serviceAccountConfig, so they are declared in exactly one
+// place (also used by applyServiceAccountSettings).
+type jsonDataSettings struct {
+	Server                 string        `json:"server"`
+	Port                   int64OrString `json:"port"`
+	Username               string        `json:"username"`
+	Timeout                int64OrString `json:"timeout"`
+	QueryTimeout           int64OrString `json:"queryTimeout"`
+	TlsMode                string        `json:"tlsMode"`
+	ConfigurationMethod    string        `json:"tlsConfigurationMethod"`
+	TlsClientCertFile      string        `json:"tlsClientCertFile"`
+	TlsClientKeyFile       string        `json:"tlsClientKeyFile"`
+	EnableSecureSocksProxy bool          `json:"enableSecureSocksProxy"`
+	MaxOpenConnections     int64OrString `json:"maxOpenConnections"`
+	MaxIdleConnections     int64OrString `json:"maxIdleConnections"`
+	MaxConnectionLifetime  int64OrString `json:"maxConnectionLifetime"`
+	TimeInterval           string        `json:"timeInterval"`
+	serviceAccountConfig
+}
+
 // LoadSettings will read and validate Settings from the DataSourceConfig
-func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings, err error) {
-	var jsonData map[string]interface{}
-	if err := json.Unmarshal(config.JSONData, &jsonData); err != nil {
+func LoadSettings(config backend.DataSourceInstanceSettings) (Settings, error) {
+	var settings Settings
+	// Single parse of the non-secret jsonData. int64OrString lets a numeric setting arrive as
+	// either a JSON number or a quoted string; a type mismatch — or a syntactically invalid
+	// document — surfaces as ErrorMessageInvalidJSON.
+	var data jsonDataSettings
+	if err := json.Unmarshal(config.JSONData, &data); err != nil {
 		return settings, fmt.Errorf("%s: %w", err.Error(), ErrorMessageInvalidJSON)
 	}
 
-	if jsonData["server"] != nil {
-		settings.Server = jsonData["server"].(string)
-	}
-	if jsonData["port"] != nil {
-		if port, ok := jsonData["port"].(string); ok {
-			settings.Port, err = strconv.ParseInt(port, 0, 64)
-			if err != nil {
-				return settings, fmt.Errorf("could not parse port value: %w", err)
-			}
-		} else {
-			settings.Port = int64(jsonData["port"].(float64))
-		}
-	}
-	if jsonData["username"] != nil {
-		settings.Username = jsonData["username"].(string)
-	}
+	settings.Server = data.Server
+	settings.Port = int64(data.Port)
+	settings.Username = data.Username
+	settings.Timeout = int64(data.Timeout)
+	settings.QueryTimeout = int64(data.QueryTimeout)
+	settings.TlsMode = data.TlsMode
+	settings.ConfigurationMethod = data.ConfigurationMethod
+	settings.TlsClientCertFile = data.TlsClientCertFile
+	settings.TlsClientKeyFile = data.TlsClientKeyFile
+	settings.EnableSecureSocksProxy = data.EnableSecureSocksProxy
+	settings.MaxOpenConnections = int64(data.MaxOpenConnections)
+	settings.MaxIdleConnections = int64(data.MaxIdleConnections)
+	settings.MaxConnectionLifetime = int64(data.MaxConnectionLifetime)
+	settings.TimeInterval = data.TimeInterval
+	data.serviceAccountConfig.applyTo(&settings)
 
-	if jsonData["timeout"] != nil {
-		if val, ok := jsonData["timeout"].(string); ok {
-			timeout, err := strconv.ParseInt(val, 0, 64)
-			if err != nil {
-				return settings, fmt.Errorf("could not parse timeout value: %w", err)
-			}
-			settings.Timeout = timeout
-		}
-		if val, ok := jsonData["timeout"].(float64); ok {
-			settings.Timeout = int64(val)
-		}
-	}
-	if jsonData["queryTimeout"] != nil {
-		if val, ok := jsonData["queryTimeout"].(int64); ok {
-			settings.QueryTimeout = val
-		}
-		if val, ok := jsonData["queryTimeout"].(float64); ok {
-			settings.QueryTimeout = int64(val)
-		}
-	}
-
-	if strings.TrimSpace(strconv.FormatInt(settings.QueryTimeout, 10)) == "" {
-		settings.QueryTimeout = 60
-	}
-	password, ok := config.DecryptedSecureJSONData["password"]
-	if ok {
+	// Secrets live in the decrypted secure JSON blob, not in jsonData.
+	if password, ok := config.DecryptedSecureJSONData["password"]; ok {
 		settings.Password = password
 	}
-	tlsCACert, ok := config.DecryptedSecureJSONData["tlsCACert"]
-	if ok {
+	if tlsCACert, ok := config.DecryptedSecureJSONData["tlsCACert"]; ok {
 		settings.TlsCACert = tlsCACert
 	}
-	tlsClientCert, ok := config.DecryptedSecureJSONData["tlsClientCert"]
-	if ok {
+	if tlsClientCert, ok := config.DecryptedSecureJSONData["tlsClientCert"]; ok {
 		settings.TlsClientCert = tlsClientCert
 	}
-	tlsClientKey, ok := config.DecryptedSecureJSONData["tlsClientKey"]
-	if ok {
+	if tlsClientKey, ok := config.DecryptedSecureJSONData["tlsClientKey"]; ok {
 		settings.TlsClientKey = tlsClientKey
 	}
-
-	if jsonData["tlsConfigurationMethod"] != nil {
-		settings.ConfigurationMethod = jsonData["tlsConfigurationMethod"].(string)
-	}
-	if jsonData["tlsMode"] != nil {
-		settings.TlsMode = jsonData["tlsMode"].(string)
-	}
-
-	if jsonData["tlsClientCertFile"] != nil {
-		settings.TlsClientCertFile = jsonData["tlsClientCertFile"].(string)
-	}
-	if jsonData["tlsClientKeyFile"] != nil {
-		settings.TlsClientKeyFile = jsonData["tlsClientKeyFile"].(string)
-	}
-
-	if jsonData["enableSecureSocksProxy"] != nil {
-		settings.EnableSecureSocksProxy = jsonData["enableSecureSocksProxy"].(bool)
-	}
-
-	if jsonData["maxOpenConnections"] != nil {
-		if maxOpenConnections, ok := jsonData["maxOpenConnections"].(string); ok {
-			settings.MaxOpenConnections, err = strconv.ParseInt(maxOpenConnections, 0, 64)
-			if err != nil {
-				return settings, fmt.Errorf("could not parse maxOpenConnections value: %w", err)
-			}
-		} else {
-			settings.MaxOpenConnections = int64(jsonData["maxOpenConnections"].(float64))
-		}
-	}
-
-	if jsonData["maxIdleConnections"] != nil {
-		if maxIdleConnections, ok := jsonData["maxIdleConnections"].(string); ok {
-			settings.MaxIdleConnections, err = strconv.ParseInt(maxIdleConnections, 0, 64)
-			if err != nil {
-				return settings, fmt.Errorf("could not parse maxIdleConnections value: %w", err)
-			}
-		} else {
-			settings.MaxIdleConnections = int64(jsonData["maxIdleConnections"].(float64))
-		}
-	}
-
-	if jsonData["maxConnectionLifetime"] != nil {
-		if maxConnectionLifetime, ok := jsonData["maxConnectionLifetime"].(string); ok {
-			settings.MaxConnectionLifetime, err = strconv.ParseInt(maxConnectionLifetime, 0, 64)
-			if err != nil {
-				return settings, fmt.Errorf("could not parse maxConnectionLifetime value: %w", err)
-			}
-		} else {
-			settings.MaxConnectionLifetime = int64(jsonData["maxConnectionLifetime"].(float64))
-		}
-	}
-
-	if jsonData["timeInterval"] != nil {
-		if timeInterval, ok := jsonData["timeInterval"].(string); ok {
-			settings.TimeInterval = timeInterval
-		}
-	}
-
-	// Service-account routing fields. Parse them through the same struct-based helper the
-	// query path (LoadServiceAccountSettings) and the config-time validator (PostCheckHealth)
-	// use, so there is a single place to add or change a routing field. The parse error is
-	// ignored here: a partial parse degrades safely (an unparseable row drops its account and
-	// the affected user falls through toward the base login), and PostCheckHealth surfaces the
-	// same type mismatch at Save & Test.
-	_ = applyServiceAccountSettings(&settings, config.JSONData)
 
 	return settings, settings.isValid()
 }
 
-// applyServiceAccountSettings parses the (non-secret) service-account routing fields from
-// jsonData onto settings and returns the json.Unmarshal error, if any. The per-query path
-// ignores that error: a partial parse degrades safely (an unparseable mapping row drops its
-// account and the affected user falls through toward the base login). Config-time callers
-// (PostCheckHealth) surface it instead, so a provisioned type mismatch — e.g. a numeric
-// serviceAccount, or a quoted boolean for the enable flag — fails Save & Test rather than
-// silently mis-routing. A whole-document syntax error cannot occur via LoadSettings (it has
-// already parsed the same bytes); the realistic error is exactly such a field type mismatch.
-func applyServiceAccountSettings(settings *Settings, jsonData []byte) error {
-	var sa struct {
-		ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
-		DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
-		ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings"`
-		ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
-		GroupsClaim                  string                       `json:"groupsClaim"`
-	}
-	err := json.Unmarshal(jsonData, &sa)
+// serviceAccountConfig is the wire shape of the (non-secret) service-account routing fields.
+// It is declared once and shared by LoadSettings (embedded in jsonDataSettings) and
+// applyServiceAccountSettings, so adding or changing a routing field touches a single struct.
+type serviceAccountConfig struct {
+	ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
+	DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
+	ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings"`
+	ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
+	GroupsClaim                  string                       `json:"groupsClaim"`
+}
+
+// applyTo copies the parsed routing fields onto settings.
+func (sa serviceAccountConfig) applyTo(settings *Settings) {
 	settings.ServiceAccountRoutingEnabled = sa.ServiceAccountRoutingEnabled
 	settings.DefaultServiceAccount = sa.DefaultServiceAccount
 	settings.ServiceAccountMappings = sa.ServiceAccountMappings
 	settings.ServiceAccountGroupMappings = sa.ServiceAccountGroupMappings
 	settings.GroupsClaim = sa.GroupsClaim
+}
+
+// applyServiceAccountSettings parses the (non-secret) service-account routing fields from
+// jsonData onto settings and returns the json.Unmarshal error, if any. The per-query path
+// (LoadServiceAccountSettings) ignores that error: a partial parse degrades safely (an
+// unparseable mapping row drops its account and the affected user falls through toward the
+// base login). Config-time callers (PostCheckHealth) surface it instead, so a provisioned
+// type mismatch — e.g. a numeric serviceAccount, or a quoted boolean for the enable flag —
+// fails Save & Test rather than silently mis-routing.
+func applyServiceAccountSettings(settings *Settings, jsonData []byte) error {
+	var sa serviceAccountConfig
+	err := json.Unmarshal(jsonData, &sa)
+	sa.applyTo(settings)
 	return err
 }
 
@@ -245,14 +220,6 @@ func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Setti
 	var settings Settings
 	_ = applyServiceAccountSettings(&settings, config.JSONData)
 	return settings
-}
-
-// resolveServiceAccount maps the requesting Grafana user (and their already-materialized
-// OIDC groups) to a QuestDB service account. See resolveServiceAccountLazy for the
-// precedence rules; this variant takes the groups in hand and is used by tests and any
-// caller that has already resolved them.
-func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
-	return settings.resolveServiceAccountLazy(user, func() []string { return groups })
 }
 
 // resolveServiceAccountLazy maps the requesting Grafana user (and their OIDC groups) to a

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -201,34 +201,15 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		}
 	}
 
-	// Service-account routing fields, read from the jsonData map already parsed above rather
-	// than unmarshaling config.JSONData a second time. The credential-free query path
-	// (LoadServiceAccountSettings) and the config-time validator (PostCheckHealth) instead
-	// decode these from raw bytes via applyServiceAccountSettings, which additionally reports
-	// the type mismatches Save & Test must surface; here a partial parse just degrades safely.
-	settings.ServiceAccountRoutingEnabled, _ = jsonData["serviceAccountRoutingEnabled"].(bool)
-	settings.DefaultServiceAccount, _ = jsonData["defaultServiceAccount"].(string)
-	settings.GroupsClaim, _ = jsonData["groupsClaim"].(string)
-	redecode(jsonData["serviceAccountMappings"], &settings.ServiceAccountMappings)
-	redecode(jsonData["serviceAccountGroupMappings"], &settings.ServiceAccountGroupMappings)
+	// Service-account routing fields. Parse them through the same struct-based helper the
+	// query path (LoadServiceAccountSettings) and the config-time validator (PostCheckHealth)
+	// use, so there is a single place to add or change a routing field. The parse error is
+	// ignored here: a partial parse degrades safely (an unparseable row drops its account and
+	// the affected user falls through toward the base login), and PostCheckHealth surfaces the
+	// same type mismatch at Save & Test.
+	_ = applyServiceAccountSettings(&settings, config.JSONData)
 
 	return settings, settings.isValid()
-}
-
-// redecode re-encodes an already-parsed JSON value (a sub-tree of the jsonData map) and
-// decodes it into dst. LoadSettings uses it to populate the typed routing slices from the
-// map it has already parsed, so config.JSONData is not unmarshaled a second time. A nil
-// value or any error leaves dst at its zero value; LoadSettings tolerates a partial routing
-// parse (PostCheckHealth reports a malformed block separately).
-func redecode(v interface{}, dst interface{}) {
-	if v == nil {
-		return
-	}
-	b, err := json.Marshal(v)
-	if err != nil {
-		return
-	}
-	_ = json.Unmarshal(b, dst)
 }
 
 // applyServiceAccountSettings parses the (non-secret) service-account routing fields from
@@ -266,21 +247,34 @@ func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Setti
 	return settings
 }
 
-// resolveServiceAccount maps the requesting Grafana user (and their OIDC groups, when
-// available) to a QuestDB service account. Precedence is most-specific-first:
+// resolveServiceAccount maps the requesting Grafana user (and their already-materialized
+// OIDC groups) to a QuestDB service account. See resolveServiceAccountLazy for the
+// precedence rules; this variant takes the groups in hand and is used by tests and any
+// caller that has already resolved them.
+func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
+	return settings.resolveServiceAccountLazy(user, func() []string { return groups })
+}
+
+// resolveServiceAccountLazy maps the requesting Grafana user (and their OIDC groups) to a
+// QuestDB service account. Precedence is most-specific-first:
 //
 //  1. username mapping  — exact (case-insensitive) match on user.Login
-//  2. group mapping     — first configured mapping whose group is in groups (case-insensitive)
+//  2. group mapping     — first configured mapping whose group is in the user's groups (case-insensitive)
 //  3. default service account
 //
 // It returns "" when none of the above yields a name (the query then runs as the base
-// login). A nil user (backend-initiated requests such as alerting/reporting) and an empty
-// groups slice both simply skip steps 1–2 and fall through to the default.
+// login). A nil user (backend-initiated requests such as alerting/reporting) simply skips
+// step 1 and falls through.
+//
+// groupsFn is invoked at most once, and only if resolution reaches step 2 (no username
+// mapping matched AND at least one group mapping is configured). This lets the caller defer
+// decoding a forwarded OIDC ID token until it is actually needed, so the token is not parsed
+// for username-mapped users or when no group mappings exist.
 //
 // Mappings with a blank service account are skipped: a half-filled config row must not
 // silently make a mapped user bypass the cap by dropping to the base login — such a user
 // falls through to the next step instead. Returned names are whitespace-trimmed.
-func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
+func (settings *Settings) resolveServiceAccountLazy(user *backend.User, groupsFn func() []string) string {
 	// 1. Username mapping (most specific). Both sides are whitespace-trimmed before the
 	// case-insensitive compare, matching the group path below, so an operator's stray
 	// space in a mapping row does not silently prevent a match.
@@ -301,16 +295,20 @@ func (settings *Settings) resolveServiceAccount(user *backend.User, groups []str
 	}
 	// 2. Group mapping. The plugin cannot see QuestDB-side limits to pick "most
 	// restrictive", so for a user in several mapped groups the first matching row in
-	// config order wins — a deterministic, operator-controlled tie-break.
-	if len(groups) > 0 {
-		for _, gm := range settings.ServiceAccountGroupMappings {
-			group := strings.TrimSpace(gm.Group)
-			sa := strings.TrimSpace(gm.ServiceAccount)
-			if group == "" || sa == "" {
-				continue
-			}
-			if containsFold(groups, group) {
-				return sa
+	// config order wins — a deterministic, operator-controlled tie-break. Resolve the
+	// user's groups lazily and only when there are mappings to match them against, so a
+	// forwarded ID token is not decoded once a username mapping has already won.
+	if len(settings.ServiceAccountGroupMappings) > 0 && groupsFn != nil {
+		if groups := groupsFn(); len(groups) > 0 {
+			for _, gm := range settings.ServiceAccountGroupMappings {
+				group := strings.TrimSpace(gm.Group)
+				sa := strings.TrimSpace(gm.ServiceAccount)
+				if group == "" || sa == "" {
+					continue
+				}
+				if containsFold(groups, group) {
+					return sa
+				}
 			}
 		}
 	}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -34,13 +34,9 @@ type Settings struct {
 	TlsClientCertFile string `json:"tlsClientCertFile"`
 	TlsClientKeyFile  string `json:"tlsClientKeyFile"`
 
-	// Per-user service-account routing (optional; QuestDB Enterprise only).
-	ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled,omitempty"`
-	DefaultServiceAccount        string                       `json:"defaultServiceAccount,omitempty"`
-	ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings,omitempty"`
-	ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings,omitempty"`
-	// GroupsClaim is the ID-token claim that holds the user's groups; defaults to "groups".
-	GroupsClaim string `json:"groupsClaim,omitempty"`
+	// Per-user service-account routing (optional; QuestDB Enterprise only). Declared once on
+	// the embedded serviceAccountConfig; Settings itself is never marshaled, so it adds no tags.
+	serviceAccountConfig
 }
 
 type CustomSetting struct {
@@ -61,6 +57,19 @@ type ServiceAccountMapping struct {
 type ServiceAccountGroupMapping struct {
 	Group          string `json:"group"`
 	ServiceAccount string `json:"serviceAccount"`
+}
+
+// serviceAccountConfig is the wire shape of the (non-secret) service-account routing fields,
+// declared exactly once and embedded wherever those fields are needed: in Settings (the domain
+// struct), in jsonDataSettings (the full single-pass parse in LoadSettings), and parsed on its
+// own by applyServiceAccountSettings. Adding or changing a routing field touches only this struct.
+type serviceAccountConfig struct {
+	ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
+	DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
+	ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings"`
+	ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
+	// GroupsClaim is the ID-token claim that holds the user's groups; defaults to "groups".
+	GroupsClaim string `json:"groupsClaim"`
 }
 
 func (settings *Settings) isValid() (err error) {
@@ -159,7 +168,7 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (Settings, error) {
 	settings.MaxIdleConnections = int64(data.MaxIdleConnections)
 	settings.MaxConnectionLifetime = int64(data.MaxConnectionLifetime)
 	settings.TimeInterval = data.TimeInterval
-	data.serviceAccountConfig.applyTo(&settings)
+	settings.serviceAccountConfig = data.serviceAccountConfig
 
 	// Secrets live in the decrypted secure JSON blob, not in jsonData.
 	if password, ok := config.DecryptedSecureJSONData["password"]; ok {
@@ -178,38 +187,17 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (Settings, error) {
 	return settings, settings.isValid()
 }
 
-// serviceAccountConfig is the wire shape of the (non-secret) service-account routing fields.
-// It is declared once and shared by LoadSettings (embedded in jsonDataSettings) and
-// applyServiceAccountSettings, so adding or changing a routing field touches a single struct.
-type serviceAccountConfig struct {
-	ServiceAccountRoutingEnabled bool                         `json:"serviceAccountRoutingEnabled"`
-	DefaultServiceAccount        string                       `json:"defaultServiceAccount"`
-	ServiceAccountMappings       []ServiceAccountMapping      `json:"serviceAccountMappings"`
-	ServiceAccountGroupMappings  []ServiceAccountGroupMapping `json:"serviceAccountGroupMappings"`
-	GroupsClaim                  string                       `json:"groupsClaim"`
-}
-
-// applyTo copies the parsed routing fields onto settings.
-func (sa serviceAccountConfig) applyTo(settings *Settings) {
-	settings.ServiceAccountRoutingEnabled = sa.ServiceAccountRoutingEnabled
-	settings.DefaultServiceAccount = sa.DefaultServiceAccount
-	settings.ServiceAccountMappings = sa.ServiceAccountMappings
-	settings.ServiceAccountGroupMappings = sa.ServiceAccountGroupMappings
-	settings.GroupsClaim = sa.GroupsClaim
-}
-
 // applyServiceAccountSettings parses the (non-secret) service-account routing fields from
-// jsonData onto settings and returns the json.Unmarshal error, if any. The per-query path
-// (LoadServiceAccountSettings) ignores that error: a partial parse degrades safely (an
-// unparseable mapping row drops its account and the affected user falls through toward the
-// base login). Config-time callers (PostCheckHealth) surface it instead, so a provisioned
-// type mismatch — e.g. a numeric serviceAccount, or a quoted boolean for the enable flag —
-// fails Save & Test rather than silently mis-routing.
+// jsonData straight onto settings' embedded serviceAccountConfig and returns the
+// json.Unmarshal error, if any. The per-query path (LoadServiceAccountSettings) ignores that
+// error: a partial parse degrades safely (an unparseable mapping row drops its account and the
+// affected user falls through toward the base login). Config-time callers (PostCheckHealth)
+// surface it instead, so a provisioned type mismatch — e.g. a numeric serviceAccount, or a
+// quoted boolean for the enable flag — fails Save & Test rather than silently mis-routing.
+// Only the embedded struct's fields are targeted, so unrelated jsonData keys (server, port, …)
+// are ignored and never trip this parse.
 func applyServiceAccountSettings(settings *Settings, jsonData []byte) error {
-	var sa serviceAccountConfig
-	err := json.Unmarshal(jsonData, &sa)
-	sa.applyTo(settings)
-	return err
+	return json.Unmarshal(jsonData, &settings.serviceAccountConfig)
 }
 
 // LoadServiceAccountSettings parses only the service-account routing fields. Unlike

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -253,14 +253,21 @@ func LoadServiceAccountSettings(config backend.DataSourceInstanceSettings) Setti
 // silently make a mapped user bypass the cap by dropping to the base login — such a user
 // falls through to the next step instead. Returned names are whitespace-trimmed.
 func (settings *Settings) resolveServiceAccount(user *backend.User, groups []string) string {
-	// 1. Username mapping (most specific).
-	if user != nil && user.Login != "" {
+	// 1. Username mapping (most specific). Both sides are whitespace-trimmed before the
+	// case-insensitive compare, matching the group path below, so an operator's stray
+	// space in a mapping row does not silently prevent a match.
+	var login string
+	if user != nil {
+		login = strings.TrimSpace(user.Login)
+	}
+	if login != "" {
 		for _, m := range settings.ServiceAccountMappings {
-			if strings.TrimSpace(m.ServiceAccount) == "" {
+			sa := strings.TrimSpace(m.ServiceAccount)
+			if sa == "" {
 				continue
 			}
-			if strings.EqualFold(m.GrafanaUser, user.Login) {
-				return strings.TrimSpace(m.ServiceAccount)
+			if strings.EqualFold(strings.TrimSpace(m.GrafanaUser), login) {
+				return sa
 			}
 		}
 	}

--- a/pkg/plugin/settings.go
+++ b/pkg/plugin/settings.go
@@ -201,13 +201,34 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 		}
 	}
 
-	// Service-account routing fields are simple native JSON types (bool/string/array),
-	// so a typed unmarshal is cleaner than the map extraction used above. A parse error is
-	// ignored here (this path also backs the per-query DriverSettings lookup); PostCheckHealth
-	// surfaces a malformed routing block at Save & Test instead.
-	_ = applyServiceAccountSettings(&settings, config.JSONData)
+	// Service-account routing fields, read from the jsonData map already parsed above rather
+	// than unmarshaling config.JSONData a second time. The credential-free query path
+	// (LoadServiceAccountSettings) and the config-time validator (PostCheckHealth) instead
+	// decode these from raw bytes via applyServiceAccountSettings, which additionally reports
+	// the type mismatches Save & Test must surface; here a partial parse just degrades safely.
+	settings.ServiceAccountRoutingEnabled, _ = jsonData["serviceAccountRoutingEnabled"].(bool)
+	settings.DefaultServiceAccount, _ = jsonData["defaultServiceAccount"].(string)
+	settings.GroupsClaim, _ = jsonData["groupsClaim"].(string)
+	redecode(jsonData["serviceAccountMappings"], &settings.ServiceAccountMappings)
+	redecode(jsonData["serviceAccountGroupMappings"], &settings.ServiceAccountGroupMappings)
 
 	return settings, settings.isValid()
+}
+
+// redecode re-encodes an already-parsed JSON value (a sub-tree of the jsonData map) and
+// decodes it into dst. LoadSettings uses it to populate the typed routing slices from the
+// map it has already parsed, so config.JSONData is not unmarshaled a second time. A nil
+// value or any error leaves dst at its zero value; LoadSettings tolerates a partial routing
+// parse (PostCheckHealth reports a malformed block separately).
+func redecode(v interface{}, dst interface{}) {
+	if v == nil {
+		return
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(b, dst)
 }
 
 // applyServiceAccountSettings parses the (non-secret) service-account routing fields from
@@ -283,11 +304,13 @@ func (settings *Settings) resolveServiceAccount(user *backend.User, groups []str
 	// config order wins — a deterministic, operator-controlled tie-break.
 	if len(groups) > 0 {
 		for _, gm := range settings.ServiceAccountGroupMappings {
-			if strings.TrimSpace(gm.Group) == "" || strings.TrimSpace(gm.ServiceAccount) == "" {
+			group := strings.TrimSpace(gm.Group)
+			sa := strings.TrimSpace(gm.ServiceAccount)
+			if group == "" || sa == "" {
 				continue
 			}
-			if containsFold(groups, strings.TrimSpace(gm.Group)) {
-				return strings.TrimSpace(gm.ServiceAccount)
+			if containsFold(groups, group) {
+				return sa
 			}
 		}
 	}

--- a/src/components/ui/MappingList.test.tsx
+++ b/src/components/ui/MappingList.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MappingColumn, MappingList } from './MappingList';
+
+interface Row {
+  user: string;
+  sa: string;
+}
+
+const columns: Array<MappingColumn<Row>> = [
+  { field: 'user', placeholder: 'user', ariaLabel: 'User' },
+  { field: 'sa', placeholder: 'sa', ariaLabel: 'Service account' },
+];
+
+// A controlled wrapper that actually applies onChange back into state, so MappingList
+// re-renders with the mutated rows. This is what exercises the stable-key reconciliation:
+// the ConfigEditor tests stub onChange with a bare jest.fn(), so the list never re-renders
+// and a broken key scheme (e.g. key={i}) would pass them unnoticed. The discriminating
+// signal is focus / DOM-node identity — the controlled `value` is always correct regardless
+// of key, but only stable keys keep the caret on the same physical input across a removal.
+function Harness({ initial }: { initial: Row[] }) {
+  const [items, setItems] = React.useState<Row[]>(initial);
+  return (
+    <MappingList<Row>
+      items={items}
+      columns={columns}
+      newRow={() => ({ user: '', sa: '' })}
+      onChange={setItems}
+      addLabel="Add mapping"
+      removeLabel="Remove"
+    />
+  );
+}
+
+const threeRows: Row[] = [
+  { user: 'a', sa: 'sa_a' },
+  { user: 'b', sa: 'sa_b' },
+  { user: 'c', sa: 'sa_c' },
+];
+
+describe('MappingList stable-key reconciliation', () => {
+  it('keeps focus and node identity on a later row when an earlier row is removed', () => {
+    render(<Harness initial={threeRows} />);
+
+    // Track the last row's input by reference, then put the caret in it.
+    const cInput = screen.getByDisplayValue('c');
+    cInput.focus();
+    expect(cInput).toHaveFocus();
+
+    // Remove the FIRST row — the maximal index shift. With index-based keys React would
+    // reconcile by position, unmount the focused node, and move 'c' onto a different element.
+    fireEvent.click(screen.getByRole('button', { name: 'Remove 1' }));
+
+    expect(screen.queryByDisplayValue('a')).not.toBeInTheDocument();
+    // Same physical node, still focused — proves reconciliation kept identity by key, not index.
+    expect(screen.getByDisplayValue('c')).toBe(cInput);
+    expect(cInput).toHaveFocus();
+  });
+
+  it('keeps focus and node identity on the last row when a middle row is removed', () => {
+    render(<Harness initial={threeRows} />);
+
+    const cInput = screen.getByDisplayValue('c');
+    cInput.focus();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove 2' }));
+
+    expect(screen.queryByDisplayValue('b')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('c')).toBe(cInput);
+    expect(cInput).toHaveFocus();
+  });
+});

--- a/src/components/ui/MappingList.tsx
+++ b/src/components/ui/MappingList.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Button, IconButton, Input } from '@grafana/ui';
+
+export interface MappingColumn<T> {
+  /** Key on the row object this column edits. */
+  field: keyof T & string;
+  placeholder: string;
+  /** Accessible-name prefix; the 1-based row number is appended (e.g. "Service account 1"). */
+  ariaLabel: string;
+}
+
+export interface MappingListProps<T> {
+  items: T[];
+  columns: Array<MappingColumn<T>>;
+  /** Factory for a blank row, used by the add button. */
+  newRow: () => T;
+  onChange: (next: T[]) => void;
+  addLabel: string;
+  /** Accessible-name prefix for each row's remove button; the 1-based row number is appended. */
+  removeLabel: string;
+}
+
+/**
+ * MappingList renders an editable list of fixed-shape, all-string rows (e.g. user → service
+ * account or group → service account mappings) with add / inline-edit / remove. Rows carry
+ * stable client-side keys so editing or removing a middle row reconciles inputs by identity
+ * rather than by position — otherwise React would move focus/caret to the wrong row.
+ */
+export function MappingList<T>({ items, columns, newRow, onChange, addLabel, removeLabel }: MappingListProps<T>) {
+  // Stable, client-only ids (never persisted): one per row, assigned lazily as rows appear.
+  // remove() drops the id at the removed index so survivors keep their identity; the
+  // render-time grow/shrink covers initial load and any external replacement of items.
+  const idsRef = React.useRef<number[]>([]);
+  const nextIdRef = React.useRef(0);
+  while (idsRef.current.length < items.length) {
+    idsRef.current.push(nextIdRef.current++);
+  }
+  if (idsRef.current.length > items.length) {
+    idsRef.current = idsRef.current.slice(0, items.length);
+  }
+
+  const update = (index: number, field: keyof T & string, value: string) =>
+    onChange(items.map((row, i) => (i === index ? ({ ...row, [field]: value } as T) : row)));
+  const remove = (index: number) => {
+    idsRef.current = idsRef.current.filter((_, i) => i !== index);
+    onChange(items.filter((_, i) => i !== index));
+  };
+  const add = () => onChange([...items, newRow()]);
+
+  return (
+    <div>
+      {items.map((row, i) => (
+        <div key={idsRef.current[i]} style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+          {columns.map((col) => (
+            <Input
+              key={col.field}
+              width={30}
+              value={String(row[col.field] ?? '')}
+              placeholder={col.placeholder}
+              aria-label={`${col.ariaLabel} ${i + 1}`}
+              onChange={(e) => update(i, col.field, e.currentTarget.value)}
+            />
+          ))}
+          <IconButton
+            name="trash-alt"
+            aria-label={`${removeLabel} ${i + 1}`}
+            tooltip={`${removeLabel} ${i + 1}`}
+            onClick={() => remove(i)}
+          />
+        </div>
+      ))}
+      <Button variant="secondary" icon="plus" onClick={add}>
+        {addLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -132,6 +132,8 @@ export const Components = {
       removeLabel: 'Remove group mapping',
       groupPlaceholder: 'OIDC/Okta group',
       serviceAccountPlaceholder: 'Service account',
+      forwardOAuthWarning:
+        'Group mappings require "Forward OAuth Identity" (above) to be enabled; without it the ID token is not forwarded and these group rows are ignored at query time.',
     },
     GroupsClaim: {
       label: 'Groups claim',

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -99,6 +99,26 @@ export const Components = {
       tooltip:
         'A lower limit for the auto-calculated interval used by $__sampleByInterval macro. Recommended to be set to write frequency, for example 1s if your data is written every second. Valid time identifiers are: ms, s, m, h, d',
     },
+    ServiceAccountRouting: {
+      label: 'Enable per-user service accounts',
+      tooltip:
+        'QuestDB Enterprise only. When enabled, each query runs ASSUME SERVICE ACCOUNT for the service account mapped to the requesting Grafana user, so the account\'s memory limit applies to that user\'s queries. The data source still authenticates with the credentials above.',
+    },
+    DefaultServiceAccount: {
+      label: 'Default service account',
+      placeholder: 'sa_default',
+      tooltip:
+        'Service account assumed for users without an explicit mapping and for backend-initiated queries (alerting, reporting). Leave empty to run unmapped users as the base login (no ASSUME).',
+    },
+    ServiceAccountMappings: {
+      label: 'User mappings',
+      tooltip:
+        'Maps a Grafana user login to a QuestDB service account. Point several users at the same service account to form a group. Matching is case-insensitive. Rows with a blank service account are ignored (the user falls back to the default).',
+      addLabel: 'Add mapping',
+      removeLabel: 'Remove service account mapping',
+      grafanaUserPlaceholder: 'Grafana user login',
+      serviceAccountPlaceholder: 'Service account',
+    },
   },
   QueryEditor: {
     CodeEditor: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -119,6 +119,20 @@ export const Components = {
       grafanaUserPlaceholder: 'Grafana user login',
       serviceAccountPlaceholder: 'Service account',
     },
+    ServiceAccountGroupMappings: {
+      label: 'Group mappings (OIDC)',
+      tooltip:
+        'Maps an OAuth/OIDC group (e.g. an Okta group from the ID token\'s "groups" claim) to a QuestDB service account. Requires "Forward OAuth Identity" enabled on this data source. A user mapping above takes precedence; when a user is in several mapped groups the first matching row (top-down) wins. Matching is case-insensitive; rows with a blank group or service account are ignored.',
+      addLabel: 'Add group mapping',
+      removeLabel: 'Remove group mapping',
+      groupPlaceholder: 'OIDC/Okta group',
+      serviceAccountPlaceholder: 'Service account',
+    },
+    GroupsClaim: {
+      label: 'Groups claim',
+      placeholder: 'groups',
+      tooltip: 'Name of the ID-token claim that holds the user\'s groups. Defaults to "groups" (the Okta default) when left empty.',
+    },
   },
   QueryEditor: {
     CodeEditor: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -119,6 +119,11 @@ export const Components = {
       grafanaUserPlaceholder: 'Grafana user login',
       serviceAccountPlaceholder: 'Service account',
     },
+    ForwardOAuthIdentity: {
+      label: 'Forward OAuth Identity',
+      tooltip:
+        'Grafana\'s standard "Forward OAuth Identity" setting. Forwards the signed-in user\'s OAuth/OIDC ID token to the plugin, which reads the user\'s groups from it. Required for the group mappings below; user mappings and the default account work without it.',
+    },
     ServiceAccountGroupMappings: {
       label: 'Group mappings (OIDC)',
       tooltip:

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,11 @@ export interface ServiceAccountMapping {
   serviceAccount: string;
 }
 
+export interface ServiceAccountGroupMapping {
+  group: string;
+  serviceAccount: string;
+}
+
 export interface QuestDBConfig extends DataSourceJsonData {
   username: string;
   server: string;
@@ -46,6 +51,9 @@ export interface QuestDBConfig extends DataSourceJsonData {
   serviceAccountRoutingEnabled?: boolean;
   defaultServiceAccount?: string;
   serviceAccountMappings?: ServiceAccountMapping[];
+  // Per-group routing via the forwarded OIDC ID token (requires "Forward OAuth Identity").
+  serviceAccountGroupMappings?: ServiceAccountGroupMapping[];
+  groupsClaim?: string;
 }
 
 export interface QuestDBSecureConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,8 @@ export interface QuestDBConfig extends DataSourceJsonData {
   // Per-group routing via the forwarded OIDC ID token (requires "Forward OAuth Identity").
   serviceAccountGroupMappings?: ServiceAccountGroupMapping[];
   groupsClaim?: string;
+  // Grafana core "Forward OAuth Identity" flag; group routing needs the forwarded ID token.
+  oauthPassThru?: boolean;
 }
 
 export interface QuestDBSecureConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,11 @@ export enum PostgresTLSMethods {
   fileContent = 'file-content',
 }
 
+export interface ServiceAccountMapping {
+  grafanaUser: string;
+  serviceAccount: string;
+}
+
 export interface QuestDBConfig extends DataSourceJsonData {
   username: string;
   server: string;
@@ -36,6 +41,11 @@ export interface QuestDBConfig extends DataSourceJsonData {
 
   tlsClientCertFile?: string;
   tlsClientKeyFile?: string;
+
+  // Per-user service-account routing (QuestDB Enterprise only).
+  serviceAccountRoutingEnabled?: boolean;
+  defaultServiceAccount?: string;
+  serviceAccountMappings?: ServiceAccountMapping[];
 }
 
 export interface QuestDBSecureConfig {

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -215,5 +215,64 @@ describe('ConfigEditor', () => {
         { grafanaUser: 'b', serviceAccount: 'sa_b2' },
       ]);
     });
+
+    it('shows group mappings and groups claim when enabled', () => {
+      render(
+        <ConfigEditor
+          {...mockConfigEditorProps({
+            serviceAccountRoutingEnabled: true,
+            groupsClaim: 'myclaim',
+            serviceAccountGroupMappings: [{ group: 'Analysts', serviceAccount: 'sa_grp' }],
+          })}
+        />
+      );
+      expect(
+        screen.getByPlaceholderText(Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder)
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Analysts')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('sa_grp')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('myclaim')).toBeInTheDocument();
+    });
+
+    it('adds a group mapping row', () => {
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(screen.getByText(Components.ConfigEditor.ServiceAccountGroupMappings.addLabel));
+      expect(lastJsonData(props).serviceAccountGroupMappings).toEqual([{ group: '', serviceAccount: '' }]);
+    });
+
+    it('updates a group mapping field', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountGroupMappings: [{ group: '', serviceAccount: '' }],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.change(
+        screen.getByPlaceholderText(Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder),
+        { target: { value: 'Engineering' } }
+      );
+      expect(lastJsonData(props).serviceAccountGroupMappings).toEqual([{ group: 'Engineering', serviceAccount: '' }]);
+    });
+
+    it('removes a group mapping row', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountGroupMappings: [{ group: 'Analysts', serviceAccount: 'sa_grp' }],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: `${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} 1` })
+      );
+      expect(lastJsonData(props).serviceAccountGroupMappings).toEqual([]);
+    });
+
+    it('editing the groups claim updates jsonData', () => {
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.change(screen.getByPlaceholderText(Components.ConfigEditor.GroupsClaim.placeholder), {
+        target: { value: 'roles' },
+      });
+      expect(lastJsonData(props).groupsClaim).toBe('roles');
+    });
   });
 });

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -138,6 +138,20 @@ describe('ConfigEditor', () => {
       expect(lastJsonData(props).serviceAccountRoutingEnabled).toBe(true);
     });
 
+    it('hides the Forward OAuth Identity switch until routing is enabled', () => {
+      render(<ConfigEditor {...mockConfigEditorProps()} />);
+      expect(
+        screen.queryByLabelText(Components.ConfigEditor.ForwardOAuthIdentity.label)
+      ).not.toBeInTheDocument();
+    });
+
+    it('toggling Forward OAuth Identity sets oauthPassThru', () => {
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(screen.getByLabelText(Components.ConfigEditor.ForwardOAuthIdentity.label));
+      expect(lastJsonData(props).oauthPassThru).toBe(true);
+    });
+
     it('adds a mapping row', () => {
       const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
       render(<ConfigEditor {...props} />);

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ConfigEditor } from './QuestDBConfigEditor';
 import { mockConfigEditorProps } from '../__mocks__/ConfigEditor';
 import { Components } from './../selectors';
@@ -97,5 +97,123 @@ describe('ConfigEditor', () => {
     render(<ConfigEditor {...mockConfigEditorProps(jsonDataOverrides)} />);
     expect(screen.getByPlaceholderText(Components.ConfigEditor.Timeout.placeholder)).toBeInTheDocument();
     expect(screen.getByText(Components.ConfigEditor.SecureSocksProxy.label)).toBeInTheDocument();
+  });
+
+  describe('service account routing', () => {
+    const lastJsonData = (props: ReturnType<typeof mockConfigEditorProps>) => {
+      const calls = (props.onOptionsChange as jest.Mock).mock.calls;
+      return calls[calls.length - 1][0].jsonData;
+    };
+
+    it('renders the routing toggle and hides details when disabled', () => {
+      render(<ConfigEditor {...mockConfigEditorProps()} />);
+      expect(screen.getByText(Components.ConfigEditor.ServiceAccountRouting.label)).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText(Components.ConfigEditor.DefaultServiceAccount.placeholder)
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows default service account and mappings when enabled', () => {
+      render(
+        <ConfigEditor
+          {...mockConfigEditorProps({
+            serviceAccountRoutingEnabled: true,
+            defaultServiceAccount: 'sa_default',
+            serviceAccountMappings: [{ grafanaUser: 'john', serviceAccount: 'sa_analysts' }],
+          })}
+        />
+      );
+      expect(
+        screen.getByPlaceholderText(Components.ConfigEditor.DefaultServiceAccount.placeholder)
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue('sa_default')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('john')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('sa_analysts')).toBeInTheDocument();
+    });
+
+    it('toggling the switch enables routing', () => {
+      const props = mockConfigEditorProps();
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(screen.getByLabelText(Components.ConfigEditor.ServiceAccountRouting.label));
+      expect(lastJsonData(props).serviceAccountRoutingEnabled).toBe(true);
+    });
+
+    it('adds a mapping row', () => {
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(screen.getByText(Components.ConfigEditor.ServiceAccountMappings.addLabel));
+      expect(lastJsonData(props).serviceAccountMappings).toEqual([{ grafanaUser: '', serviceAccount: '' }]);
+    });
+
+    it('updates a mapping field', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountMappings: [{ grafanaUser: '', serviceAccount: '' }],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.change(screen.getByPlaceholderText(Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder), {
+        target: { value: 'alice' },
+      });
+      expect(lastJsonData(props).serviceAccountMappings).toEqual([{ grafanaUser: 'alice', serviceAccount: '' }]);
+    });
+
+    it('removes a mapping row', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountMappings: [{ grafanaUser: 'john', serviceAccount: 'sa_analysts' }],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: `${Components.ConfigEditor.ServiceAccountMappings.removeLabel} 1` })
+      );
+      expect(lastJsonData(props).serviceAccountMappings).toEqual([]);
+    });
+
+    it('editing the default service account updates jsonData', () => {
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.change(screen.getByPlaceholderText(Components.ConfigEditor.DefaultServiceAccount.placeholder), {
+        target: { value: 'sa_default' },
+      });
+      expect(lastJsonData(props).defaultServiceAccount).toBe('sa_default');
+    });
+
+    it('removes the correct row among several', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountMappings: [
+          { grafanaUser: 'a', serviceAccount: 'sa_a' },
+          { grafanaUser: 'b', serviceAccount: 'sa_b' },
+          { grafanaUser: 'c', serviceAccount: 'sa_c' },
+        ],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: `${Components.ConfigEditor.ServiceAccountMappings.removeLabel} 2` })
+      );
+      expect(lastJsonData(props).serviceAccountMappings).toEqual([
+        { grafanaUser: 'a', serviceAccount: 'sa_a' },
+        { grafanaUser: 'c', serviceAccount: 'sa_c' },
+      ]);
+    });
+
+    it('updates the correct row among several', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountMappings: [
+          { grafanaUser: 'a', serviceAccount: 'sa_a' },
+          { grafanaUser: 'b', serviceAccount: 'sa_b' },
+        ],
+      });
+      render(<ConfigEditor {...props} />);
+      const saInputs = screen.getAllByPlaceholderText(
+        Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder
+      );
+      fireEvent.change(saInputs[1], { target: { value: 'sa_b2' } });
+      expect(lastJsonData(props).serviceAccountMappings).toEqual([
+        { grafanaUser: 'a', serviceAccount: 'sa_a' },
+        { grafanaUser: 'b', serviceAccount: 'sa_b2' },
+      ]);
+    });
   });
 });

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -326,5 +326,41 @@ describe('ConfigEditor', () => {
         { group: 'B', serviceAccount: 'sa_b2' },
       ]);
     });
+
+    it('warns when group mappings exist but Forward OAuth Identity is off', () => {
+      render(
+        <ConfigEditor
+          {...mockConfigEditorProps({
+            serviceAccountRoutingEnabled: true,
+            serviceAccountGroupMappings: [{ group: 'Analysts', serviceAccount: 'sa_grp' }],
+          })}
+        />
+      );
+      expect(
+        screen.getByText(Components.ConfigEditor.ServiceAccountGroupMappings.forwardOAuthWarning)
+      ).toBeInTheDocument();
+    });
+
+    it('hides the warning once Forward OAuth Identity is enabled', () => {
+      render(
+        <ConfigEditor
+          {...mockConfigEditorProps({
+            serviceAccountRoutingEnabled: true,
+            oauthPassThru: true,
+            serviceAccountGroupMappings: [{ group: 'Analysts', serviceAccount: 'sa_grp' }],
+          })}
+        />
+      );
+      expect(
+        screen.queryByText(Components.ConfigEditor.ServiceAccountGroupMappings.forwardOAuthWarning)
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not warn when there are no group mappings', () => {
+      render(<ConfigEditor {...mockConfigEditorProps({ serviceAccountRoutingEnabled: true })} />);
+      expect(
+        screen.queryByText(Components.ConfigEditor.ServiceAccountGroupMappings.forwardOAuthWarning)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -138,6 +138,17 @@ describe('ConfigEditor', () => {
       expect(lastJsonData(props).serviceAccountRoutingEnabled).toBe(true);
     });
 
+    it('disabling routing also clears Forward OAuth Identity', () => {
+      // oauthPassThru is only reachable from inside the routing block, so turning routing off
+      // must clear it too — otherwise it is stranded on with no UI to disable it.
+      const props = mockConfigEditorProps({ serviceAccountRoutingEnabled: true, oauthPassThru: true });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(screen.getByLabelText(Components.ConfigEditor.ServiceAccountRouting.label));
+      const jd = lastJsonData(props);
+      expect(jd.serviceAccountRoutingEnabled).toBe(false);
+      expect(jd.oauthPassThru).toBe(false);
+    });
+
     it('hides the Forward OAuth Identity switch until routing is enabled', () => {
       render(<ConfigEditor {...mockConfigEditorProps()} />);
       expect(

--- a/src/views/QuestDBConfigEditor.test.tsx
+++ b/src/views/QuestDBConfigEditor.test.tsx
@@ -274,5 +274,43 @@ describe('ConfigEditor', () => {
       });
       expect(lastJsonData(props).groupsClaim).toBe('roles');
     });
+
+    it('removes the correct group row among several', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountGroupMappings: [
+          { group: 'A', serviceAccount: 'sa_a' },
+          { group: 'B', serviceAccount: 'sa_b' },
+          { group: 'C', serviceAccount: 'sa_c' },
+        ],
+      });
+      render(<ConfigEditor {...props} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: `${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} 2` })
+      );
+      expect(lastJsonData(props).serviceAccountGroupMappings).toEqual([
+        { group: 'A', serviceAccount: 'sa_a' },
+        { group: 'C', serviceAccount: 'sa_c' },
+      ]);
+    });
+
+    it('updates the correct group row among several', () => {
+      const props = mockConfigEditorProps({
+        serviceAccountRoutingEnabled: true,
+        serviceAccountGroupMappings: [
+          { group: 'A', serviceAccount: 'sa_a' },
+          { group: 'B', serviceAccount: 'sa_b' },
+        ],
+      });
+      render(<ConfigEditor {...props} />);
+      // Query by the group-specific service-account aria-label so this stays unambiguous even
+      // when the user-mapping list (which shares the "Service account" placeholder) also renders.
+      const groupSaLabel = `${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder} 2`;
+      fireEvent.change(screen.getByLabelText(groupSaLabel), { target: { value: 'sa_b2' } });
+      expect(lastJsonData(props).serviceAccountGroupMappings).toEqual([
+        { group: 'A', serviceAccount: 'sa_a' },
+        { group: 'B', serviceAccount: 'sa_b2' },
+      ]);
+    });
   });
 });

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -482,7 +482,7 @@ export const ConfigEditor: React.FC<Props> = (props) => {
                       width={30}
                       value={m.serviceAccount}
                       placeholder={Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder}
-                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} service account ${i + 1}`}
+                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder} ${i + 1}`}
                       onChange={(e) => onUpdateGroupMapping(i, 'serviceAccount', e.currentTarget.value)}
                     />
                     <IconButton

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -5,8 +5,9 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   SelectableValue,
 } from '@grafana/data';
-import { Button, Field, IconButton, Input, SecretInput, Select, Switch } from '@grafana/ui';
+import { Field, Input, SecretInput, Select, Switch } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
+import { MappingList } from '../components/ui/MappingList';
 import { Components } from './../selectors';
 import {
   PostgresTLSModes,
@@ -70,10 +71,6 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
-  const onAddMapping = () => onMappingsChange([...mappings, { grafanaUser: '', serviceAccount: '' }]);
-  const onRemoveMapping = (index: number) => onMappingsChange(mappings.filter((_, i) => i !== index));
-  const onUpdateMapping = (index: number, key: keyof ServiceAccountMapping, value: string) =>
-    onMappingsChange(mappings.map((m, i) => (i === index ? { ...m, [key]: value } : m)));
 
   const groupMappings = jsonData.serviceAccountGroupMappings ?? [];
   const onGroupMappingsChange = (next: ServiceAccountGroupMapping[]) => {
@@ -85,10 +82,6 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
-  const onAddGroupMapping = () => onGroupMappingsChange([...groupMappings, { group: '', serviceAccount: '' }]);
-  const onRemoveGroupMapping = (index: number) => onGroupMappingsChange(groupMappings.filter((_, i) => i !== index));
-  const onUpdateGroupMapping = (index: number, key: keyof ServiceAccountGroupMapping, value: string) =>
-    onGroupMappingsChange(groupMappings.map((m, i) => (i === index ? { ...m, [key]: value } : m)));
 
   const onCertificateChangeFactory = (key: keyof Omit<QuestDBSecureConfig, 'password'>, value: string) => {
     onOptionsChange({
@@ -418,35 +411,25 @@ export const ConfigEditor: React.FC<Props> = (props) => {
               label={Components.ConfigEditor.ServiceAccountMappings.label}
               description={Components.ConfigEditor.ServiceAccountMappings.tooltip}
             >
-              <div>
-                {mappings.map((m, i) => (
-                  <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
-                    <Input
-                      width={30}
-                      value={m.grafanaUser}
-                      placeholder={Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder}
-                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder} ${i + 1}`}
-                      onChange={(e) => onUpdateMapping(i, 'grafanaUser', e.currentTarget.value)}
-                    />
-                    <Input
-                      width={30}
-                      value={m.serviceAccount}
-                      placeholder={Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder}
-                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder} ${i + 1}`}
-                      onChange={(e) => onUpdateMapping(i, 'serviceAccount', e.currentTarget.value)}
-                    />
-                    <IconButton
-                      name="trash-alt"
-                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.removeLabel} ${i + 1}`}
-                      tooltip={`${Components.ConfigEditor.ServiceAccountMappings.removeLabel} ${i + 1}`}
-                      onClick={() => onRemoveMapping(i)}
-                    />
-                  </div>
-                ))}
-                <Button variant="secondary" icon="plus" onClick={onAddMapping}>
-                  {Components.ConfigEditor.ServiceAccountMappings.addLabel}
-                </Button>
-              </div>
+              <MappingList<ServiceAccountMapping>
+                items={mappings}
+                newRow={() => ({ grafanaUser: '', serviceAccount: '' })}
+                onChange={onMappingsChange}
+                addLabel={Components.ConfigEditor.ServiceAccountMappings.addLabel}
+                removeLabel={Components.ConfigEditor.ServiceAccountMappings.removeLabel}
+                columns={[
+                  {
+                    field: 'grafanaUser',
+                    placeholder: Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder,
+                    ariaLabel: Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder,
+                  },
+                  {
+                    field: 'serviceAccount',
+                    placeholder: Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder,
+                    ariaLabel: Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder,
+                  },
+                ]}
+              />
             </Field>
 
             <Field
@@ -468,35 +451,25 @@ export const ConfigEditor: React.FC<Props> = (props) => {
               label={Components.ConfigEditor.ServiceAccountGroupMappings.label}
               description={Components.ConfigEditor.ServiceAccountGroupMappings.tooltip}
             >
-              <div>
-                {groupMappings.map((m, i) => (
-                  <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
-                    <Input
-                      width={30}
-                      value={m.group}
-                      placeholder={Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder}
-                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${i + 1}`}
-                      onChange={(e) => onUpdateGroupMapping(i, 'group', e.currentTarget.value)}
-                    />
-                    <Input
-                      width={30}
-                      value={m.serviceAccount}
-                      placeholder={Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder}
-                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder} ${i + 1}`}
-                      onChange={(e) => onUpdateGroupMapping(i, 'serviceAccount', e.currentTarget.value)}
-                    />
-                    <IconButton
-                      name="trash-alt"
-                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} ${i + 1}`}
-                      tooltip={`${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} ${i + 1}`}
-                      onClick={() => onRemoveGroupMapping(i)}
-                    />
-                  </div>
-                ))}
-                <Button variant="secondary" icon="plus" onClick={onAddGroupMapping}>
-                  {Components.ConfigEditor.ServiceAccountGroupMappings.addLabel}
-                </Button>
-              </div>
+              <MappingList<ServiceAccountGroupMapping>
+                items={groupMappings}
+                newRow={() => ({ group: '', serviceAccount: '' })}
+                onChange={onGroupMappingsChange}
+                addLabel={Components.ConfigEditor.ServiceAccountGroupMappings.addLabel}
+                removeLabel={Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel}
+                columns={[
+                  {
+                    field: 'group',
+                    placeholder: Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder,
+                    ariaLabel: Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder,
+                  },
+                  {
+                    field: 'serviceAccount',
+                    placeholder: Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder,
+                    ariaLabel: `${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder}`,
+                  },
+                ]}
+              />
             </Field>
           </>
         )}

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -49,7 +49,10 @@ export const ConfigEditor: React.FC<Props> = (props) => {
     });
   };
   const onSwitchToggle = (
-    key: keyof Pick<QuestDBConfig, 'validate' | 'enableSecureSocksProxy' | 'serviceAccountRoutingEnabled'>,
+    key: keyof Pick<
+      QuestDBConfig,
+      'validate' | 'enableSecureSocksProxy' | 'serviceAccountRoutingEnabled' | 'oauthPassThru'
+    >,
     value: boolean
   ) => {
     onOptionsChange({
@@ -429,6 +432,18 @@ export const ConfigEditor: React.FC<Props> = (props) => {
                     ariaLabel: Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder,
                   },
                 ]}
+              />
+            </Field>
+
+            <Field
+              label={Components.ConfigEditor.ForwardOAuthIdentity.label}
+              description={Components.ConfigEditor.ForwardOAuthIdentity.tooltip}
+            >
+              <Switch
+                className="gf-form"
+                aria-label={Components.ConfigEditor.ForwardOAuthIdentity.label}
+                value={jsonData.oauthPassThru || false}
+                onChange={(e) => onSwitchToggle('oauthPassThru', e.currentTarget.checked)}
               />
             </Field>
 

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -5,7 +5,7 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   SelectableValue,
 } from '@grafana/data';
-import { Field, Input, SecretInput, Select, Switch } from '@grafana/ui';
+import { Alert, Field, Input, SecretInput, Select, Switch } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import { MappingList } from '../components/ui/MappingList';
 import { Components } from './../selectors';
@@ -48,13 +48,7 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
-  const onSwitchToggle = (
-    key: keyof Pick<
-      QuestDBConfig,
-      'validate' | 'enableSecureSocksProxy' | 'serviceAccountRoutingEnabled' | 'oauthPassThru'
-    >,
-    value: boolean
-  ) => {
+  const setJsonData = <K extends keyof QuestDBConfig>(key: K, value: QuestDBConfig[K]) => {
     onOptionsChange({
       ...options,
       jsonData: {
@@ -63,28 +57,20 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
+  const onSwitchToggle = (
+    key: keyof Pick<
+      QuestDBConfig,
+      'validate' | 'enableSecureSocksProxy' | 'serviceAccountRoutingEnabled' | 'oauthPassThru'
+    >,
+    value: boolean
+  ) => setJsonData(key, value);
 
   const mappings = jsonData.serviceAccountMappings ?? [];
-  const onMappingsChange = (next: ServiceAccountMapping[]) => {
-    onOptionsChange({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        serviceAccountMappings: next,
-      },
-    });
-  };
+  const onMappingsChange = (next: ServiceAccountMapping[]) => setJsonData('serviceAccountMappings', next);
 
   const groupMappings = jsonData.serviceAccountGroupMappings ?? [];
-  const onGroupMappingsChange = (next: ServiceAccountGroupMapping[]) => {
-    onOptionsChange({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        serviceAccountGroupMappings: next,
-      },
-    });
-  };
+  const onGroupMappingsChange = (next: ServiceAccountGroupMapping[]) =>
+    setJsonData('serviceAccountGroupMappings', next);
 
   const onCertificateChangeFactory = (key: keyof Omit<QuestDBSecureConfig, 'password'>, value: string) => {
     onOptionsChange({
@@ -461,6 +447,13 @@ export const ConfigEditor: React.FC<Props> = (props) => {
                 placeholder={Components.ConfigEditor.GroupsClaim.placeholder}
               />
             </Field>
+
+            {groupMappings.length > 0 && !jsonData.oauthPassThru && (
+              <Alert
+                severity="warning"
+                title={Components.ConfigEditor.ServiceAccountGroupMappings.forwardOAuthWarning}
+              />
+            )}
 
             <Field
               label={Components.ConfigEditor.ServiceAccountGroupMappings.label}

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -72,6 +72,22 @@ export const ConfigEditor: React.FC<Props> = (props) => {
   const onGroupMappingsChange = (next: ServiceAccountGroupMapping[]) =>
     setJsonData('serviceAccountGroupMappings', next);
 
+  // Turning routing off also clears Forward OAuth Identity: that switch lives inside the
+  // routing block, so leaving oauthPassThru on would strand it with no UI to turn it back
+  // off while Grafana keeps forwarding the user's OAuth token to the backend. The other
+  // routing fields (default account, mappings) are inert when routing is off and are kept,
+  // so an accidental toggle does not discard the operator's configured mappings.
+  const onRoutingToggle = (enabled: boolean) => {
+    if (enabled) {
+      setJsonData('serviceAccountRoutingEnabled', true);
+      return;
+    }
+    onOptionsChange({
+      ...options,
+      jsonData: { ...options.jsonData, serviceAccountRoutingEnabled: false, oauthPassThru: false },
+    });
+  };
+
   const onCertificateChangeFactory = (key: keyof Omit<QuestDBSecureConfig, 'password'>, value: string) => {
     onOptionsChange({
       ...options,
@@ -375,7 +391,7 @@ export const ConfigEditor: React.FC<Props> = (props) => {
             className="gf-form"
             aria-label={Components.ConfigEditor.ServiceAccountRouting.label}
             value={jsonData.serviceAccountRoutingEnabled || false}
-            onChange={(e) => onSwitchToggle('serviceAccountRoutingEnabled', e.currentTarget.checked)}
+            onChange={(e) => onRoutingToggle(e.currentTarget.checked)}
           />
         </Field>
 

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -5,10 +5,10 @@ import {
   onUpdateDatasourceSecureJsonDataOption,
   SelectableValue,
 } from '@grafana/data';
-import { Field, Input, SecretInput, Select, Switch } from '@grafana/ui';
+import { Button, Field, IconButton, Input, SecretInput, Select, Switch } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import { Components } from './../selectors';
-import { PostgresTLSModes, QuestDBConfig, QuestDBSecureConfig } from './../types';
+import { PostgresTLSModes, QuestDBConfig, QuestDBSecureConfig, ServiceAccountMapping } from './../types';
 import { gte } from 'semver';
 import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
@@ -41,7 +41,10 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
-  const onSwitchToggle = (key: keyof Pick<QuestDBConfig, 'validate' | 'enableSecureSocksProxy'>, value: boolean) => {
+  const onSwitchToggle = (
+    key: keyof Pick<QuestDBConfig, 'validate' | 'enableSecureSocksProxy' | 'serviceAccountRoutingEnabled'>,
+    value: boolean
+  ) => {
     onOptionsChange({
       ...options,
       jsonData: {
@@ -50,6 +53,21 @@ export const ConfigEditor: React.FC<Props> = (props) => {
       },
     });
   };
+
+  const mappings = jsonData.serviceAccountMappings ?? [];
+  const onMappingsChange = (next: ServiceAccountMapping[]) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        serviceAccountMappings: next,
+      },
+    });
+  };
+  const onAddMapping = () => onMappingsChange([...mappings, { grafanaUser: '', serviceAccount: '' }]);
+  const onRemoveMapping = (index: number) => onMappingsChange(mappings.filter((_, i) => i !== index));
+  const onUpdateMapping = (index: number, key: keyof ServiceAccountMapping, value: string) =>
+    onMappingsChange(mappings.map((m, i) => (i === index ? { ...m, [key]: value } : m)));
 
   const onCertificateChangeFactory = (key: keyof Omit<QuestDBSecureConfig, 'password'>, value: string) => {
     onOptionsChange({
@@ -342,6 +360,75 @@ export const ConfigEditor: React.FC<Props> = (props) => {
             </>
           </>
         ) : null}
+      </ConfigSection>
+
+      <Divider />
+      <ConfigSection title="Per-user service accounts">
+        <Field
+          label={Components.ConfigEditor.ServiceAccountRouting.label}
+          description={Components.ConfigEditor.ServiceAccountRouting.tooltip}
+        >
+          <Switch
+            className="gf-form"
+            aria-label={Components.ConfigEditor.ServiceAccountRouting.label}
+            value={jsonData.serviceAccountRoutingEnabled || false}
+            onChange={(e) => onSwitchToggle('serviceAccountRoutingEnabled', e.currentTarget.checked)}
+          />
+        </Field>
+
+        {jsonData.serviceAccountRoutingEnabled && (
+          <>
+            <Field
+              label={Components.ConfigEditor.DefaultServiceAccount.label}
+              description={Components.ConfigEditor.DefaultServiceAccount.tooltip}
+            >
+              <Input
+                name="defaultServiceAccount"
+                width={40}
+                value={jsonData.defaultServiceAccount || ''}
+                onChange={onUpdateDatasourceJsonDataOption(props, 'defaultServiceAccount')}
+                label={Components.ConfigEditor.DefaultServiceAccount.label}
+                aria-label={Components.ConfigEditor.DefaultServiceAccount.label}
+                placeholder={Components.ConfigEditor.DefaultServiceAccount.placeholder}
+              />
+            </Field>
+
+            <Field
+              label={Components.ConfigEditor.ServiceAccountMappings.label}
+              description={Components.ConfigEditor.ServiceAccountMappings.tooltip}
+            >
+              <div>
+                {mappings.map((m, i) => (
+                  <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+                    <Input
+                      width={30}
+                      value={m.grafanaUser}
+                      placeholder={Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder}
+                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.grafanaUserPlaceholder} ${i + 1}`}
+                      onChange={(e) => onUpdateMapping(i, 'grafanaUser', e.currentTarget.value)}
+                    />
+                    <Input
+                      width={30}
+                      value={m.serviceAccount}
+                      placeholder={Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder}
+                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.serviceAccountPlaceholder} ${i + 1}`}
+                      onChange={(e) => onUpdateMapping(i, 'serviceAccount', e.currentTarget.value)}
+                    />
+                    <IconButton
+                      name="trash-alt"
+                      aria-label={`${Components.ConfigEditor.ServiceAccountMappings.removeLabel} ${i + 1}`}
+                      tooltip={`${Components.ConfigEditor.ServiceAccountMappings.removeLabel} ${i + 1}`}
+                      onClick={() => onRemoveMapping(i)}
+                    />
+                  </div>
+                ))}
+                <Button variant="secondary" icon="plus" onClick={onAddMapping}>
+                  {Components.ConfigEditor.ServiceAccountMappings.addLabel}
+                </Button>
+              </div>
+            </Field>
+          </>
+        )}
       </ConfigSection>
       <Divider />
     </>

--- a/src/views/QuestDBConfigEditor.tsx
+++ b/src/views/QuestDBConfigEditor.tsx
@@ -8,7 +8,13 @@ import {
 import { Button, Field, IconButton, Input, SecretInput, Select, Switch } from '@grafana/ui';
 import { CertificationKey } from '../components/ui/CertificationKey';
 import { Components } from './../selectors';
-import { PostgresTLSModes, QuestDBConfig, QuestDBSecureConfig, ServiceAccountMapping } from './../types';
+import {
+  PostgresTLSModes,
+  QuestDBConfig,
+  QuestDBSecureConfig,
+  ServiceAccountGroupMapping,
+  ServiceAccountMapping,
+} from './../types';
 import { gte } from 'semver';
 import { ConfigSection, DataSourceDescription } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
@@ -68,6 +74,21 @@ export const ConfigEditor: React.FC<Props> = (props) => {
   const onRemoveMapping = (index: number) => onMappingsChange(mappings.filter((_, i) => i !== index));
   const onUpdateMapping = (index: number, key: keyof ServiceAccountMapping, value: string) =>
     onMappingsChange(mappings.map((m, i) => (i === index ? { ...m, [key]: value } : m)));
+
+  const groupMappings = jsonData.serviceAccountGroupMappings ?? [];
+  const onGroupMappingsChange = (next: ServiceAccountGroupMapping[]) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        serviceAccountGroupMappings: next,
+      },
+    });
+  };
+  const onAddGroupMapping = () => onGroupMappingsChange([...groupMappings, { group: '', serviceAccount: '' }]);
+  const onRemoveGroupMapping = (index: number) => onGroupMappingsChange(groupMappings.filter((_, i) => i !== index));
+  const onUpdateGroupMapping = (index: number, key: keyof ServiceAccountGroupMapping, value: string) =>
+    onGroupMappingsChange(groupMappings.map((m, i) => (i === index ? { ...m, [key]: value } : m)));
 
   const onCertificateChangeFactory = (key: keyof Omit<QuestDBSecureConfig, 'password'>, value: string) => {
     onOptionsChange({
@@ -424,6 +445,56 @@ export const ConfigEditor: React.FC<Props> = (props) => {
                 ))}
                 <Button variant="secondary" icon="plus" onClick={onAddMapping}>
                   {Components.ConfigEditor.ServiceAccountMappings.addLabel}
+                </Button>
+              </div>
+            </Field>
+
+            <Field
+              label={Components.ConfigEditor.GroupsClaim.label}
+              description={Components.ConfigEditor.GroupsClaim.tooltip}
+            >
+              <Input
+                name="groupsClaim"
+                width={40}
+                value={jsonData.groupsClaim || ''}
+                onChange={onUpdateDatasourceJsonDataOption(props, 'groupsClaim')}
+                label={Components.ConfigEditor.GroupsClaim.label}
+                aria-label={Components.ConfigEditor.GroupsClaim.label}
+                placeholder={Components.ConfigEditor.GroupsClaim.placeholder}
+              />
+            </Field>
+
+            <Field
+              label={Components.ConfigEditor.ServiceAccountGroupMappings.label}
+              description={Components.ConfigEditor.ServiceAccountGroupMappings.tooltip}
+            >
+              <div>
+                {groupMappings.map((m, i) => (
+                  <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '8px', alignItems: 'center' }}>
+                    <Input
+                      width={30}
+                      value={m.group}
+                      placeholder={Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder}
+                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} ${i + 1}`}
+                      onChange={(e) => onUpdateGroupMapping(i, 'group', e.currentTarget.value)}
+                    />
+                    <Input
+                      width={30}
+                      value={m.serviceAccount}
+                      placeholder={Components.ConfigEditor.ServiceAccountGroupMappings.serviceAccountPlaceholder}
+                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.groupPlaceholder} service account ${i + 1}`}
+                      onChange={(e) => onUpdateGroupMapping(i, 'serviceAccount', e.currentTarget.value)}
+                    />
+                    <IconButton
+                      name="trash-alt"
+                      aria-label={`${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} ${i + 1}`}
+                      tooltip={`${Components.ConfigEditor.ServiceAccountGroupMappings.removeLabel} ${i + 1}`}
+                      onClick={() => onRemoveGroupMapping(i)}
+                    />
+                  </div>
+                ))}
+                <Button variant="secondary" icon="plus" onClick={onAddGroupMapping}>
+                  {Components.ConfigEditor.ServiceAccountGroupMappings.addLabel}
                 </Button>
               </div>
             </Field>


### PR DESCRIPTION
## Summary

Opt-in **per-Grafana-user and per-group QuestDB memory limits** for a single shared data
source (QuestDB **Enterprise 4.0.2+**). When enabled, each query runs `ASSUME SERVICE ACCOUNT <sa>`
for the service account mapped to the requesting Grafana user — by **username**, or by
**OIDC/Okta group** carried in the forwarded ID token — so the account's memory limit caps
that user's queries. The limits live on the QuestDB side; the plugin just forwards identity
and assumes an account.

Builds on the now-merged per-query memory limits (questdb/questdb#7184) and per-principal
memory limits (questdb/questdb-enterprise#1039).

**Disabled by default** — when off (or for queries without a mapped account), sqlds returns
the default pool and behavior is identical to before.

## How it works

- **Identity** — backend-verified `req.PluginContext.User.Login` (tamper-proof, no Grafana
  API call), mirroring the Trino plugin's approach.
- **Group identity (OIDC)** — when group mappings are configured and **Forward OAuth
  Identity** (`oauthPassThru`) is on, the user's groups are read from the forwarded ID token
  (`X-Id-Token`) by decoding the JWT payload. The token is injected by the Grafana server
  from the user's session, so it is unforgeable from the query payload. No signature/expiry
  verification and no new dependency — governance, not a security boundary. The PII-bearing
  token is read only when group mappings exist.
- **Resolution precedence** — `username mapping → group mapping → default service account`.
  For a user in several mapped groups, the first configured group row wins; blank rows are
  skipped; matching is case-insensitive.
- **Routing** — `MutateQueryData` resolves the account and stamps `{"serviceAccount": "..."}`
  into each query's `connectionArgs`, replacing or stripping any client-supplied value under
  every key casing sqlds' case-insensitive decoder accepts. With `EnableMultipleConnections`,
  sqlds keeps one connection pool per service account; the driver hands concurrent first
  uses of an account one shared pool and owns the routed pools, so sqlds' non-atomic pool
  creation cannot orphan pools past `Dispose`: disposing the instance also closes a pool a
  query opened but sqlds had not yet cached, and refuses new routed pools.
- **Session identity pinned on reuse** — with routing enabled, a `driver.Connector` wrapper
  keeps each pooled connection at the identity its pool stands for, so an `EXIT` or `ASSUME`
  in one user's SQL does not carry over to the next user of that connection. A routed pool
  runs `ASSUME SERVICE ACCOUNT "<sa>"` on each new connection and again before each reuse
  (QuestDB authorizes ASSUME against the login's own grants, so repeating it is safe; a failed
  re-ASSUME discards the connection). The base login pool, used for unrouted queries, checks
  `current_user()` against `session_user()` before each reuse and discards a connection still
  assuming an account. Either costs one extra round trip per query on a reused connection;
  routing-disabled data sources are unchanged.
- **Save & Test** — validates account names and, when a default account is set, runs a real
  ASSUME against it, so a missing `GRANT ASSUME`, a missing `GRANT PGWIRE` on the account, or
  a non-existent account fails at config time.
- **Config** — opt-in toggle, default service account, `username → service account` and
  `OIDC group → service account` mappings, and an optional `groupsClaim` (all non-secret
  `jsonData`). Unmapped users, backend-initiated queries (alerting/reporting), missing tokens,
  and blank rows fall back to the default.

## Memory-limit semantics (QuestDB side)

As merged in questdb-enterprise#1039:
- After ASSUME, queries run under the service account's own limit. An account with no limit
  falls back to `cairo.query.memory.limit.bytes`; an account limit overrides it even when larger.
- Service accounts never inherit QuestDB group limits, so the limit must be set on the account.
- The limit caps each query, not a shared budget: concurrent queries from users mapped to the
  same account each run under the full limit.
- A changed limit applies to the next query, including on pooled connections Grafana already
  holds open.

## Security model

Resource governance, not a hard tenant boundary (consistent with the underlying QuestDB
feature):
- Both identities are set by the Grafana server, not the query payload — a user cannot pick a
  different account or group by editing the request (`connectionArgs` is plugin-owned in any
  key casing, and routed arguments without a service account are refused).
- Service-account names are validated against QuestDB's own entity-name denylist (which
  forbids `"` and `\`) before being embedded as a quoted identifier (injection-safe).
- The OIDC groups claim is read without verifying the token signature or expiry (deliberate —
  it sidesteps Grafana forwarding stale tokens); worst case a user's group membership is up to
  one token-lifetime stale, which only changes which equally-authorized limit applies.
- Raw SQL can `EXIT SERVICE ACCOUNT <sa>` (reverting to the base login's limit) or `ASSUME` another
  account the login is granted, for the rest of that query, so set a memory limit on the base
  login too and grant it only the accounts used here. Neither outlives the query: the pool
  restores or replaces the connection before its next user. Don't use the
  built-in `admin` as the data source login: it can assume any account without a grant and
  cannot be given a memory limit.
- SAML logins mint no OIDC ID token → group routing is unavailable there; those users fall
  back to username mappings + the default.

## Tests

- **Backend unit**: resolver (username/group precedence, first-group-wins, case-insensitive,
  nil user, blank-row fallback, whitespace trim), `extractGroups` (default/custom/missing
  claim, non-JWT, non-base64url payload, non-string-array, empty header), statement builder +
  injection guard, connector wrapper (success / exec-error / missing lib/pq interfaces /
  dial-error / close hook), pooled reuse through `database/sql` with a stateful fake session
  (routed: identity restored after `EXIT` or a switching `ASSUME`, failed re-ASSUME discards
  the connection; base login: a connection left assuming an account is discarded, a clean one
  is reused), `MutateQueryData` (username + `X-Id-Token` group cases, and client
  `connectionArgs` in exact, lower, upper, and Unicode-folded casings, empty, and null — for
  mapped, default, and unrouted users — decoded through `sqlds.GetQuery`),
  `withConnectionArgs` edges, `PostCheckHealth`, `Connect` wiring, and pool sharing
  (concurrent first use, closed-pool replacement, the health probe leaving the shared pool
  open, and a barrier-forced concurrent first use through the real sqlds connector where
  `Dispose` closes every pool handed out), and disposal overlapping a query's pool creation
  (a pool opened but not yet cached is closed; a creation resuming after disposal is refused).
- **Integration** (gated behind `QUESTDB_ENTERPRISE=true`; run against a build of
  questdb-enterprise `main` with #1039): routes through a dedicated non-admin login and covers
  ASSUME through a routed pool, service-account limit enforcement, a changed limit reaching an
  open connection, the account's limit replacing the base login's, the cap surviving a prior
  error on a reused connection, `EXIT SERVICE ACCOUNT` reverting to the base login's limit, the
  next user of a connection released after `EXIT` running under the account's limit again,
  `current_user()`/`session_user()` differing exactly while an account is assumed (including a
  clean built-in admin session), a base login connection released while assuming an account
  running its next query as the login, and
  Save & Test failing on a missing `GRANT ASSUME`, a missing `GRANT PGWIRE`, and a non-existent
  account.
- **Frontend**: config-editor section — toggle, default SA, user + group mappings
  (add/update/remove incl. multi-row index correctness), groups claim, Forward OAuth Identity
  toggle and warning; `MappingList` stable-key reconciliation.

## Operator setup

Requires QuestDB **Enterprise 4.0.2+** at runtime. On the QuestDB side, each service account
needs `GRANT PGWIRE` (ASSUME over PGWire checks the account's own endpoint permission) and a
memory limit, and the data source login needs `GRANT ASSUME SERVICE ACCOUNT`. For group
routing, enable **Forward OAuth Identity** on the data source and emit a `groups` claim in the
OIDC (e.g. Okta) **ID token**. No `plugin.json` change. The README has the QuestDB-side setup,
the OIDC/Okta setup, and provisioning examples for both username and group mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



